### PR TITLE
Fix share feature to allow unicode characters

### DIFF
--- a/src/app/services/decode.service.ts
+++ b/src/app/services/decode.service.ts
@@ -26,7 +26,7 @@ export class DecodeService {
       sticking: this.localStorageService.getSticking(),
     };
     return encodeURIComponent(
-      btoa(
+      this.encodeToBase64(
         JSON.stringify(teamBoard)
       )
     );
@@ -34,9 +34,17 @@ export class DecodeService {
 
   decode(value: string): TeamBoard {
     return JSON.parse(
-      atob(
+      this.decodeFromBase64(
         decodeURIComponent(value)
       )
     );
+  }
+
+  private encodeToBase64(value: string): string {
+    return btoa(unescape(encodeURIComponent(value)));
+  }
+
+  private decodeFromBase64(value: string): string {
+    return decodeURIComponent(escape(atob(value)));
   }
 }


### PR DESCRIPTION
I noticed that the share button didn't work if there were any devs or boards that contained unicode characters like emojis. It looks like this is caused by the btoa and atob methods not allowing these characters by default.

I implemented the solution from stack overflow and it looks like it works now:
https://stackoverflow.com/a/33626659