### PR TITLE
Update rotation logic so that carrying devs stay on the same board

### DIFF
--- a/src/app/services/board.service.spec.ts
+++ b/src/app/services/board.service.spec.ts
@@ -4,302 +4,302 @@ import { shuffle } from '../utillity/lulz';
 
 describe('BoardService', () => {
 
-    const localStorageService = {
-        getBoards: jest.fn(),
-        getDisabledBoards: jest.fn(),
-        getPairs: jest.fn(),
-        getSticking: jest.fn(),
+  const localStorageService = {
+    getBoards: jest.fn(),
+    getDisabledBoards: jest.fn(),
+    getPairs: jest.fn(),
+    getSticking: jest.fn(),
 
-        setBoards: jest.fn(),
-        setDisabledBoards: jest.fn(),
-        setPairs: jest.fn(),
-        setSticking: jest.fn()
-    };
+    setBoards: jest.fn(),
+    setDisabledBoards: jest.fn(),
+    setPairs: jest.fn(),
+    setSticking: jest.fn()
+  };
 
-    const boardService = new BoardService(localStorageService as any);
+  const boardService = new BoardService(localStorageService as any);
 
-    afterEach(() => {
-        jest.resetAllMocks();
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('update', () => {
+    const oldBoardName = faker.unique(faker.address.country);
+    const updatedBoardName = faker.unique(faker.address.country);
+
+    const firstOtherBoardName = faker.unique(faker.address.country);
+    const secondOtherBoardName = faker.unique(faker.address.country);
+
+    const firstPairDevs = [faker.name.firstName(), faker.name.firstName()];
+    const secondPairDevs = [faker.name.firstName(), faker.name.firstName()];
+
+    it('should update board name in every list that contains the board name', () => {
+
+      localStorageService.getBoards.mockReturnValue(shuffle([
+        oldBoardName,
+        firstOtherBoardName,
+        secondOtherBoardName
+      ]));
+
+      localStorageService.getDisabledBoards.mockReturnValue(shuffle([
+        oldBoardName,
+        firstOtherBoardName
+      ]));
+
+      localStorageService.getPairs.mockReturnValue(shuffle([
+        {board: oldBoardName, devs: firstPairDevs},
+        {board: secondOtherBoardName, devs: secondPairDevs}
+      ]));
+
+      localStorageService.getSticking.mockReturnValue(shuffle([
+        {board: oldBoardName, devs: firstPairDevs},
+        {board: secondOtherBoardName, devs: secondPairDevs}
+      ]));
+
+      boardService.update(oldBoardName, updatedBoardName);
+
+      expect(localStorageService.setBoards).toHaveBeenCalledWith(expect.toIncludeSameMembers([
+        updatedBoardName,
+        firstOtherBoardName,
+        secondOtherBoardName
+      ]));
+
+      expect(localStorageService.setDisabledBoards).toHaveBeenCalledWith(expect.toIncludeSameMembers([
+        updatedBoardName,
+        firstOtherBoardName
+      ]));
+
+      expect(localStorageService.setPairs).toHaveBeenCalledWith(expect.toIncludeSameMembers([
+        {board: updatedBoardName, devs: firstPairDevs},
+        {board: secondOtherBoardName, devs: secondPairDevs}
+      ]));
+
+      expect(localStorageService.setSticking).toHaveBeenCalledWith(expect.toIncludeSameMembers([
+        {board: updatedBoardName, devs: firstPairDevs},
+        {board: secondOtherBoardName, devs: secondPairDevs}
+      ]));
     });
 
-    describe('update', () => {
-        const oldBoardName = faker.unique(faker.address.country);
-        const updatedBoardName = faker.unique(faker.address.country);
+    it('should not update disabled boards when board is not disabled', () => {
 
-        const firstOtherBoardName = faker.unique(faker.address.country);
-        const secondOtherBoardName = faker.unique(faker.address.country);
+      localStorageService.getBoards.mockReturnValue(shuffle([
+        oldBoardName,
+        firstOtherBoardName,
+        secondOtherBoardName
+      ]));
 
-        const firstPairDevs = [faker.name.firstName(), faker.name.firstName()];
-        const secondPairDevs = [faker.name.firstName(), faker.name.firstName()];
+      localStorageService.getDisabledBoards.mockReturnValue(shuffle([
+        secondOtherBoardName,
+        firstOtherBoardName
+      ]));
 
-        it('should update board name in every list that contains the board name', () => {
+      localStorageService.getPairs.mockReturnValue(shuffle([
+        {board: oldBoardName, devs: firstPairDevs},
+        {board: secondOtherBoardName, devs: secondPairDevs}
+      ]));
 
-            localStorageService.getBoards.mockReturnValue(shuffle([
-                oldBoardName,
-                firstOtherBoardName,
-                secondOtherBoardName
-            ]));
+      localStorageService.getSticking.mockReturnValue(shuffle([
+        {board: oldBoardName, devs: firstPairDevs},
+        {board: secondOtherBoardName, devs: secondPairDevs}
+      ]));
 
-            localStorageService.getDisabledBoards.mockReturnValue(shuffle([
-                oldBoardName,
-                firstOtherBoardName
-            ]));
+      boardService.update(oldBoardName, updatedBoardName);
 
-            localStorageService.getPairs.mockReturnValue(shuffle([
-                {board: oldBoardName, devs: firstPairDevs},
-                {board: secondOtherBoardName, devs: secondPairDevs}
-            ]));
-
-            localStorageService.getSticking.mockReturnValue(shuffle([
-                {board: oldBoardName, devs: firstPairDevs},
-                {board: secondOtherBoardName, devs: secondPairDevs}
-            ]));
-
-            boardService.update(oldBoardName, updatedBoardName);
-
-            expect(localStorageService.setBoards).toHaveBeenCalledWith(expect.toIncludeSameMembers([
-                updatedBoardName,
-                firstOtherBoardName,
-                secondOtherBoardName
-            ]));
-
-            expect(localStorageService.setDisabledBoards).toHaveBeenCalledWith(expect.toIncludeSameMembers([
-                updatedBoardName,
-                firstOtherBoardName
-            ]));
-
-            expect(localStorageService.setPairs).toHaveBeenCalledWith(expect.toIncludeSameMembers([
-                {board: updatedBoardName, devs: firstPairDevs},
-                {board: secondOtherBoardName, devs: secondPairDevs}
-            ]));
-
-            expect(localStorageService.setSticking).toHaveBeenCalledWith(expect.toIncludeSameMembers([
-                {board: updatedBoardName, devs: firstPairDevs},
-                {board: secondOtherBoardName, devs: secondPairDevs}
-            ]));
-        });
-
-        it('should not update disabled boards when board is not disabled', () => {
-
-            localStorageService.getBoards.mockReturnValue(shuffle([
-                oldBoardName,
-                firstOtherBoardName,
-                secondOtherBoardName
-            ]));
-
-            localStorageService.getDisabledBoards.mockReturnValue(shuffle([
-                secondOtherBoardName,
-                firstOtherBoardName
-            ]));
-
-            localStorageService.getPairs.mockReturnValue(shuffle([
-                {board: oldBoardName, devs: firstPairDevs},
-                {board: secondOtherBoardName, devs: secondPairDevs}
-            ]));
-
-            localStorageService.getSticking.mockReturnValue(shuffle([
-                {board: oldBoardName, devs: firstPairDevs},
-                {board: secondOtherBoardName, devs: secondPairDevs}
-            ]));
-
-            boardService.update(oldBoardName, updatedBoardName);
-
-            expect(localStorageService.setDisabledBoards).not.toHaveBeenCalled();
-        });
-
-        it('should not update pairs when board is not in a pair', () => {
-
-            localStorageService.getBoards.mockReturnValue(shuffle([
-                oldBoardName,
-                firstOtherBoardName,
-                secondOtherBoardName
-            ]));
-
-            localStorageService.getDisabledBoards.mockReturnValue(shuffle([
-                oldBoardName,
-                firstOtherBoardName
-            ]));
-
-            localStorageService.getPairs.mockReturnValue(shuffle([
-                {board: firstOtherBoardName, devs: firstPairDevs},
-                {board: secondOtherBoardName, devs: secondPairDevs}
-            ]));
-
-            localStorageService.getSticking.mockReturnValue(shuffle([
-                {board: oldBoardName, devs: firstPairDevs},
-                {board: secondOtherBoardName, devs: secondPairDevs}
-            ]));
-
-            boardService.update(oldBoardName, updatedBoardName);
-
-            expect(localStorageService.setPairs).not.toHaveBeenCalled();
-        });
-
-        it('should not update sticking pairs when board is not in a sticking pair', () => {
-
-            localStorageService.getBoards.mockReturnValue(shuffle([
-                oldBoardName,
-                firstOtherBoardName,
-                secondOtherBoardName
-            ]));
-
-            localStorageService.getDisabledBoards.mockReturnValue(shuffle([
-                oldBoardName,
-                firstOtherBoardName
-            ]));
-
-            localStorageService.getPairs.mockReturnValue(shuffle([
-                {board: oldBoardName, devs: firstPairDevs},
-                {board: secondOtherBoardName, devs: secondPairDevs}
-            ]));
-
-            localStorageService.getSticking.mockReturnValue(shuffle([
-                {board: firstOtherBoardName, devs: firstPairDevs},
-                {board: secondOtherBoardName, devs: secondPairDevs}
-            ]));
-
-            boardService.update(oldBoardName, updatedBoardName);
-
-            expect(localStorageService.setSticking).not.toHaveBeenCalled();
-        });
+      expect(localStorageService.setDisabledBoards).not.toHaveBeenCalled();
     });
 
-    describe('delete', () => {
-        const boardToDelete = faker.unique(faker.address.country);
+    it('should not update pairs when board is not in a pair', () => {
 
-        const firstOtherBoardName = faker.unique(faker.address.country);
-        const secondOtherBoardName = faker.unique(faker.address.country);
+      localStorageService.getBoards.mockReturnValue(shuffle([
+        oldBoardName,
+        firstOtherBoardName,
+        secondOtherBoardName
+      ]));
 
-        const firstPairDevs = [faker.name.firstName(), faker.name.firstName()];
-        const secondPairDevs = [faker.name.firstName(), faker.name.firstName()];
+      localStorageService.getDisabledBoards.mockReturnValue(shuffle([
+        oldBoardName,
+        firstOtherBoardName
+      ]));
 
-        it('should remove board name in every list that contains the board name', () => {
+      localStorageService.getPairs.mockReturnValue(shuffle([
+        {board: firstOtherBoardName, devs: firstPairDevs},
+        {board: secondOtherBoardName, devs: secondPairDevs}
+      ]));
 
-            localStorageService.getBoards.mockReturnValue(shuffle([
-                boardToDelete,
-                firstOtherBoardName,
-                secondOtherBoardName
-            ]));
+      localStorageService.getSticking.mockReturnValue(shuffle([
+        {board: oldBoardName, devs: firstPairDevs},
+        {board: secondOtherBoardName, devs: secondPairDevs}
+      ]));
 
-            localStorageService.getDisabledBoards.mockReturnValue(shuffle([
-                boardToDelete,
-                firstOtherBoardName
-            ]));
+      boardService.update(oldBoardName, updatedBoardName);
 
-            localStorageService.getPairs.mockReturnValue(shuffle([
-                {board: boardToDelete, devs: firstPairDevs},
-                {board: secondOtherBoardName, devs: secondPairDevs}
-            ]));
-
-            localStorageService.getSticking.mockReturnValue(shuffle([
-                {board: boardToDelete, devs: firstPairDevs},
-                {board: secondOtherBoardName, devs: secondPairDevs}
-            ]));
-
-            boardService.delete(boardToDelete);
-
-            expect(localStorageService.setBoards).toHaveBeenCalledWith(expect.toIncludeSameMembers([
-                firstOtherBoardName,
-                secondOtherBoardName
-            ]));
-
-            expect(localStorageService.setDisabledBoards).toHaveBeenCalledWith(expect.toIncludeSameMembers([
-                firstOtherBoardName
-            ]));
-
-            expect(localStorageService.setPairs).toHaveBeenCalledWith(expect.toIncludeSameMembers([
-                {devs: firstPairDevs},
-                {board: secondOtherBoardName, devs: secondPairDevs}
-            ]));
-
-            expect(localStorageService.setSticking).toHaveBeenCalledWith(expect.toIncludeSameMembers([
-                {devs: firstPairDevs},
-                {board: secondOtherBoardName, devs: secondPairDevs}
-            ]));
-        });
-
-        it('should not update disabled boards when board is not disabled', () => {
-
-            localStorageService.getBoards.mockReturnValue(shuffle([
-                boardToDelete,
-                firstOtherBoardName,
-                secondOtherBoardName
-            ]));
-
-            localStorageService.getDisabledBoards.mockReturnValue(shuffle([
-                secondOtherBoardName,
-                firstOtherBoardName
-            ]));
-
-            localStorageService.getPairs.mockReturnValue(shuffle([
-                {board: boardToDelete, devs: firstPairDevs},
-                {board: secondOtherBoardName, devs: secondPairDevs}
-            ]));
-
-            localStorageService.getSticking.mockReturnValue(shuffle([
-                {board: boardToDelete, devs: firstPairDevs},
-                {board: secondOtherBoardName, devs: secondPairDevs}
-            ]));
-
-            boardService.delete(boardToDelete);
-
-            expect(localStorageService.setDisabledBoards).not.toHaveBeenCalled();
-        });
-
-        it('should not update pairs when board is not in a pair', () => {
-
-            localStorageService.getBoards.mockReturnValue(shuffle([
-                boardToDelete,
-                firstOtherBoardName,
-                secondOtherBoardName
-            ]));
-
-            localStorageService.getDisabledBoards.mockReturnValue(shuffle([
-                boardToDelete,
-                firstOtherBoardName
-            ]));
-
-            localStorageService.getPairs.mockReturnValue(shuffle([
-                {board: firstOtherBoardName, devs: firstPairDevs},
-                {board: secondOtherBoardName, devs: secondPairDevs}
-            ]));
-
-            localStorageService.getSticking.mockReturnValue(shuffle([
-                {board: boardToDelete, devs: firstPairDevs},
-                {board: secondOtherBoardName, devs: secondPairDevs}
-            ]));
-
-            boardService.delete(boardToDelete);
-
-            expect(localStorageService.setPairs).not.toHaveBeenCalled();
-        });
-
-        it('should not update sticking pairs when board is not in a sticking pair', () => {
-
-            localStorageService.getBoards.mockReturnValue(shuffle([
-                boardToDelete,
-                firstOtherBoardName,
-                secondOtherBoardName
-            ]));
-
-            localStorageService.getDisabledBoards.mockReturnValue(shuffle([
-                boardToDelete,
-                firstOtherBoardName
-            ]));
-
-            localStorageService.getPairs.mockReturnValue(shuffle([
-                {board: boardToDelete, devs: firstPairDevs},
-                {board: secondOtherBoardName, devs: secondPairDevs}
-            ]));
-
-            localStorageService.getSticking.mockReturnValue(shuffle([
-                {board: firstOtherBoardName, devs: firstPairDevs},
-                {board: secondOtherBoardName, devs: secondPairDevs}
-            ]));
-
-            boardService.delete(boardToDelete);
-
-            expect(localStorageService.setSticking).not.toHaveBeenCalled();
-        });
+      expect(localStorageService.setPairs).not.toHaveBeenCalled();
     });
+
+    it('should not update sticking pairs when board is not in a sticking pair', () => {
+
+      localStorageService.getBoards.mockReturnValue(shuffle([
+        oldBoardName,
+        firstOtherBoardName,
+        secondOtherBoardName
+      ]));
+
+      localStorageService.getDisabledBoards.mockReturnValue(shuffle([
+        oldBoardName,
+        firstOtherBoardName
+      ]));
+
+      localStorageService.getPairs.mockReturnValue(shuffle([
+        {board: oldBoardName, devs: firstPairDevs},
+        {board: secondOtherBoardName, devs: secondPairDevs}
+      ]));
+
+      localStorageService.getSticking.mockReturnValue(shuffle([
+        {board: firstOtherBoardName, devs: firstPairDevs},
+        {board: secondOtherBoardName, devs: secondPairDevs}
+      ]));
+
+      boardService.update(oldBoardName, updatedBoardName);
+
+      expect(localStorageService.setSticking).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('delete', () => {
+    const boardToDelete = faker.unique(faker.address.country);
+
+    const firstOtherBoardName = faker.unique(faker.address.country);
+    const secondOtherBoardName = faker.unique(faker.address.country);
+
+    const firstPairDevs = [faker.name.firstName(), faker.name.firstName()];
+    const secondPairDevs = [faker.name.firstName(), faker.name.firstName()];
+
+    it('should remove board name in every list that contains the board name', () => {
+
+      localStorageService.getBoards.mockReturnValue(shuffle([
+        boardToDelete,
+        firstOtherBoardName,
+        secondOtherBoardName
+      ]));
+
+      localStorageService.getDisabledBoards.mockReturnValue(shuffle([
+        boardToDelete,
+        firstOtherBoardName
+      ]));
+
+      localStorageService.getPairs.mockReturnValue(shuffle([
+        {board: boardToDelete, devs: firstPairDevs},
+        {board: secondOtherBoardName, devs: secondPairDevs}
+      ]));
+
+      localStorageService.getSticking.mockReturnValue(shuffle([
+        {board: boardToDelete, devs: firstPairDevs},
+        {board: secondOtherBoardName, devs: secondPairDevs}
+      ]));
+
+      boardService.delete(boardToDelete);
+
+      expect(localStorageService.setBoards).toHaveBeenCalledWith(expect.toIncludeSameMembers([
+        firstOtherBoardName,
+        secondOtherBoardName
+      ]));
+
+      expect(localStorageService.setDisabledBoards).toHaveBeenCalledWith(expect.toIncludeSameMembers([
+        firstOtherBoardName
+      ]));
+
+      expect(localStorageService.setPairs).toHaveBeenCalledWith(expect.toIncludeSameMembers([
+        {devs: firstPairDevs},
+        {board: secondOtherBoardName, devs: secondPairDevs}
+      ]));
+
+      expect(localStorageService.setSticking).toHaveBeenCalledWith(expect.toIncludeSameMembers([
+        {devs: firstPairDevs},
+        {board: secondOtherBoardName, devs: secondPairDevs}
+      ]));
+    });
+
+    it('should not update disabled boards when board is not disabled', () => {
+
+      localStorageService.getBoards.mockReturnValue(shuffle([
+        boardToDelete,
+        firstOtherBoardName,
+        secondOtherBoardName
+      ]));
+
+      localStorageService.getDisabledBoards.mockReturnValue(shuffle([
+        secondOtherBoardName,
+        firstOtherBoardName
+      ]));
+
+      localStorageService.getPairs.mockReturnValue(shuffle([
+        {board: boardToDelete, devs: firstPairDevs},
+        {board: secondOtherBoardName, devs: secondPairDevs}
+      ]));
+
+      localStorageService.getSticking.mockReturnValue(shuffle([
+        {board: boardToDelete, devs: firstPairDevs},
+        {board: secondOtherBoardName, devs: secondPairDevs}
+      ]));
+
+      boardService.delete(boardToDelete);
+
+      expect(localStorageService.setDisabledBoards).not.toHaveBeenCalled();
+    });
+
+    it('should not update pairs when board is not in a pair', () => {
+
+      localStorageService.getBoards.mockReturnValue(shuffle([
+        boardToDelete,
+        firstOtherBoardName,
+        secondOtherBoardName
+      ]));
+
+      localStorageService.getDisabledBoards.mockReturnValue(shuffle([
+        boardToDelete,
+        firstOtherBoardName
+      ]));
+
+      localStorageService.getPairs.mockReturnValue(shuffle([
+        {board: firstOtherBoardName, devs: firstPairDevs},
+        {board: secondOtherBoardName, devs: secondPairDevs}
+      ]));
+
+      localStorageService.getSticking.mockReturnValue(shuffle([
+        {board: boardToDelete, devs: firstPairDevs},
+        {board: secondOtherBoardName, devs: secondPairDevs}
+      ]));
+
+      boardService.delete(boardToDelete);
+
+      expect(localStorageService.setPairs).not.toHaveBeenCalled();
+    });
+
+    it('should not update sticking pairs when board is not in a sticking pair', () => {
+
+      localStorageService.getBoards.mockReturnValue(shuffle([
+        boardToDelete,
+        firstOtherBoardName,
+        secondOtherBoardName
+      ]));
+
+      localStorageService.getDisabledBoards.mockReturnValue(shuffle([
+        boardToDelete,
+        firstOtherBoardName
+      ]));
+
+      localStorageService.getPairs.mockReturnValue(shuffle([
+        {board: boardToDelete, devs: firstPairDevs},
+        {board: secondOtherBoardName, devs: secondPairDevs}
+      ]));
+
+      localStorageService.getSticking.mockReturnValue(shuffle([
+        {board: firstOtherBoardName, devs: firstPairDevs},
+        {board: secondOtherBoardName, devs: secondPairDevs}
+      ]));
+
+      boardService.delete(boardToDelete);
+
+      expect(localStorageService.setSticking).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/app/services/dev.service.spec.ts
+++ b/src/app/services/dev.service.spec.ts
@@ -4,441 +4,441 @@ import { shuffle } from '../utillity/lulz';
 
 describe('DevService', () => {
 
-    const localStorageService = {
-        getDevs: jest.fn(),
-        getDisabled: jest.fn(),
-        getCarriers: jest.fn(),
-        getPairs: jest.fn(),
-        getSticking: jest.fn(),
+  const localStorageService = {
+    getDevs: jest.fn(),
+    getDisabled: jest.fn(),
+    getCarriers: jest.fn(),
+    getPairs: jest.fn(),
+    getSticking: jest.fn(),
 
-        setDevs: jest.fn(),
-        setDisabled: jest.fn(),
-        setCarriers: jest.fn(),
-        setPairs: jest.fn(),
-        setSticking: jest.fn(),
-    };
+    setDevs: jest.fn(),
+    setDisabled: jest.fn(),
+    setCarriers: jest.fn(),
+    setPairs: jest.fn(),
+    setSticking: jest.fn(),
+  };
 
-    const devService = new DevService(localStorageService as any);
+  const devService = new DevService(localStorageService as any);
 
-    afterEach(() => {
-        jest.resetAllMocks();
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('update', () => {
+    const oldDevName = faker.unique(faker.name.firstName);
+    const updatedDevName = faker.unique(faker.name.firstName);
+
+    const firstOtherDevName = faker.unique(faker.name.firstName);
+    const secondOtherDevName = faker.unique(faker.name.firstName);
+    const thirdOtherDevName = faker.unique(faker.name.firstName);
+    const fourthOtherDevName = faker.unique(faker.name.firstName);
+
+    it('should update dev name in every list that contains the dev name', () => {
+
+      localStorageService.getDevs.mockReturnValue(shuffle([
+        oldDevName,
+        firstOtherDevName,
+        secondOtherDevName,
+        thirdOtherDevName,
+        fourthOtherDevName
+      ]));
+
+      localStorageService.getDisabled.mockReturnValue(shuffle([
+        oldDevName,
+        firstOtherDevName
+      ]));
+
+      localStorageService.getCarriers.mockReturnValue(shuffle([
+        oldDevName,
+        secondOtherDevName
+      ]));
+
+      localStorageService.getPairs.mockReturnValue(shuffle([
+        {devs: shuffle([oldDevName, firstOtherDevName])},
+        {devs: shuffle([secondOtherDevName, thirdOtherDevName])}
+      ]));
+
+      localStorageService.getSticking.mockReturnValue(shuffle([
+        {devs: shuffle([oldDevName, firstOtherDevName])},
+        {devs: shuffle([secondOtherDevName, thirdOtherDevName])}
+      ]));
+
+      devService.update(oldDevName, updatedDevName);
+
+      expect(localStorageService.setDevs).toHaveBeenCalledWith(expect.toIncludeSameMembers([
+        updatedDevName,
+        firstOtherDevName,
+        secondOtherDevName,
+        thirdOtherDevName,
+        fourthOtherDevName
+      ]));
+
+      expect(localStorageService.setDisabled).toHaveBeenCalledWith(expect.toIncludeSameMembers([
+        updatedDevName,
+        firstOtherDevName
+      ]));
+
+      expect(localStorageService.setCarriers).toHaveBeenCalledWith(expect.toIncludeSameMembers([
+        updatedDevName,
+        secondOtherDevName
+      ]));
+
+      expect(localStorageService.setPairs).toHaveBeenCalledWith(expect.toIncludeSameMembers([
+        {devs: expect.toIncludeSameMembers([updatedDevName, firstOtherDevName])},
+        {devs: expect.toIncludeSameMembers([secondOtherDevName, thirdOtherDevName])},
+      ]));
+
+      expect(localStorageService.setSticking).toHaveBeenCalledWith(expect.toIncludeSameMembers([
+        {devs: expect.toIncludeSameMembers([updatedDevName, firstOtherDevName])},
+        {devs: expect.toIncludeSameMembers([secondOtherDevName, thirdOtherDevName])},
+      ]));
     });
 
-    describe('update', () => {
-        const oldDevName = faker.unique(faker.name.firstName);
-        const updatedDevName = faker.unique(faker.name.firstName);
+    it('should not update disabled devs when dev is not disabled', () => {
 
-        const firstOtherDevName = faker.unique(faker.name.firstName);
-        const secondOtherDevName = faker.unique(faker.name.firstName);
-        const thirdOtherDevName = faker.unique(faker.name.firstName);
-        const fourthOtherDevName = faker.unique(faker.name.firstName);
+      localStorageService.getDevs.mockReturnValue(shuffle([
+        oldDevName,
+        firstOtherDevName,
+        secondOtherDevName,
+        thirdOtherDevName,
+        fourthOtherDevName
+      ]));
 
-        it('should update dev name in every list that contains the dev name', () => {
+      localStorageService.getDisabled.mockReturnValue(shuffle([
+        fourthOtherDevName,
+        firstOtherDevName
+      ]));
 
-            localStorageService.getDevs.mockReturnValue(shuffle([
-                oldDevName,
-                firstOtherDevName,
-                secondOtherDevName,
-                thirdOtherDevName,
-                fourthOtherDevName
-            ]));
+      localStorageService.getCarriers.mockReturnValue(shuffle([
+        oldDevName,
+        secondOtherDevName
+      ]));
 
-            localStorageService.getDisabled.mockReturnValue(shuffle([
-                oldDevName,
-                firstOtherDevName
-            ]));
+      localStorageService.getPairs.mockReturnValue(shuffle([
+        {devs: shuffle([oldDevName, firstOtherDevName])},
+        {devs: shuffle([secondOtherDevName, thirdOtherDevName])}
+      ]));
 
-            localStorageService.getCarriers.mockReturnValue(shuffle([
-                oldDevName,
-                secondOtherDevName
-            ]));
+      localStorageService.getSticking.mockReturnValue(shuffle([
+        {devs: shuffle([oldDevName, firstOtherDevName])},
+        {devs: shuffle([secondOtherDevName, thirdOtherDevName])}
+      ]));
 
-            localStorageService.getPairs.mockReturnValue(shuffle([
-                {devs: shuffle([oldDevName, firstOtherDevName])},
-                {devs: shuffle([secondOtherDevName, thirdOtherDevName])}
-            ]));
+      devService.update(oldDevName, updatedDevName);
 
-            localStorageService.getSticking.mockReturnValue(shuffle([
-                {devs: shuffle([oldDevName, firstOtherDevName])},
-                {devs: shuffle([secondOtherDevName, thirdOtherDevName])}
-            ]));
-
-            devService.update(oldDevName, updatedDevName);
-
-            expect(localStorageService.setDevs).toHaveBeenCalledWith(expect.toIncludeSameMembers([
-                updatedDevName,
-                firstOtherDevName,
-                secondOtherDevName,
-                thirdOtherDevName,
-                fourthOtherDevName
-            ]));
-
-            expect(localStorageService.setDisabled).toHaveBeenCalledWith(expect.toIncludeSameMembers([
-                updatedDevName,
-                firstOtherDevName
-            ]));
-
-            expect(localStorageService.setCarriers).toHaveBeenCalledWith(expect.toIncludeSameMembers([
-                updatedDevName,
-                secondOtherDevName
-            ]));
-
-            expect(localStorageService.setPairs).toHaveBeenCalledWith(expect.toIncludeSameMembers([
-                {devs: expect.toIncludeSameMembers([updatedDevName, firstOtherDevName])},
-                {devs: expect.toIncludeSameMembers([secondOtherDevName, thirdOtherDevName])},
-            ]));
-
-            expect(localStorageService.setSticking).toHaveBeenCalledWith(expect.toIncludeSameMembers([
-                {devs: expect.toIncludeSameMembers([updatedDevName, firstOtherDevName])},
-                {devs: expect.toIncludeSameMembers([secondOtherDevName, thirdOtherDevName])},
-            ]));
-        });
-
-        it('should not update disabled devs when dev is not disabled', () => {
-
-            localStorageService.getDevs.mockReturnValue(shuffle([
-                oldDevName,
-                firstOtherDevName,
-                secondOtherDevName,
-                thirdOtherDevName,
-                fourthOtherDevName
-            ]));
-
-            localStorageService.getDisabled.mockReturnValue(shuffle([
-                fourthOtherDevName,
-                firstOtherDevName
-            ]));
-
-            localStorageService.getCarriers.mockReturnValue(shuffle([
-                oldDevName,
-                secondOtherDevName
-            ]));
-
-            localStorageService.getPairs.mockReturnValue(shuffle([
-                {devs: shuffle([oldDevName, firstOtherDevName])},
-                {devs: shuffle([secondOtherDevName, thirdOtherDevName])}
-            ]));
-
-            localStorageService.getSticking.mockReturnValue(shuffle([
-                {devs: shuffle([oldDevName, firstOtherDevName])},
-                {devs: shuffle([secondOtherDevName, thirdOtherDevName])}
-            ]));
-
-            devService.update(oldDevName, updatedDevName);
-
-            expect(localStorageService.setDisabled).not.toHaveBeenCalled();
-        });
-
-        it('should not update carrying devs when dev is not carrying', () => {
-
-            localStorageService.getDevs.mockReturnValue(shuffle([
-                oldDevName,
-                firstOtherDevName,
-                secondOtherDevName,
-                thirdOtherDevName,
-                fourthOtherDevName
-            ]));
-
-            localStorageService.getDisabled.mockReturnValue(shuffle([
-                oldDevName,
-                firstOtherDevName
-            ]));
-
-            localStorageService.getCarriers.mockReturnValue(shuffle([
-                fourthOtherDevName,
-                secondOtherDevName
-            ]));
-
-            localStorageService.getPairs.mockReturnValue(shuffle([
-                {devs: shuffle([oldDevName, firstOtherDevName])},
-                {devs: shuffle([secondOtherDevName, thirdOtherDevName])}
-            ]));
-
-            localStorageService.getSticking.mockReturnValue(shuffle([
-                {devs: shuffle([oldDevName, firstOtherDevName])},
-                {devs: shuffle([secondOtherDevName, thirdOtherDevName])}
-            ]));
-
-            devService.update(oldDevName, updatedDevName);
-
-            expect(localStorageService.setCarriers).not.toHaveBeenCalled();
-        });
-
-        it('should not update pairs when dev is not paired', () => {
-
-            localStorageService.getDevs.mockReturnValue(shuffle([
-                oldDevName,
-                firstOtherDevName,
-                secondOtherDevName,
-                thirdOtherDevName,
-                fourthOtherDevName
-            ]));
-
-            localStorageService.getDisabled.mockReturnValue(shuffle([
-                oldDevName,
-                firstOtherDevName
-            ]));
-
-            localStorageService.getCarriers.mockReturnValue(shuffle([
-                firstOtherDevName,
-                secondOtherDevName
-            ]));
-
-            localStorageService.getPairs.mockReturnValue(shuffle([
-                {devs: shuffle([fourthOtherDevName, firstOtherDevName])},
-                {devs: shuffle([secondOtherDevName, thirdOtherDevName])}
-            ]));
-
-            localStorageService.getSticking.mockReturnValue(shuffle([
-                {devs: shuffle([oldDevName, firstOtherDevName])},
-                {devs: shuffle([secondOtherDevName, thirdOtherDevName])}
-            ]));
-
-            devService.update(oldDevName, updatedDevName);
-
-            expect(localStorageService.setPairs).not.toHaveBeenCalled();
-        });
-
-        it('should not update sticking pairs when dev is not sticking', () => {
-
-            localStorageService.getDevs.mockReturnValue(shuffle([
-                oldDevName,
-                firstOtherDevName,
-                secondOtherDevName,
-                thirdOtherDevName,
-                fourthOtherDevName
-            ]));
-
-            localStorageService.getDisabled.mockReturnValue(shuffle([
-                oldDevName,
-                firstOtherDevName
-            ]));
-
-            localStorageService.getCarriers.mockReturnValue(shuffle([
-                firstOtherDevName,
-                secondOtherDevName
-            ]));
-
-            localStorageService.getPairs.mockReturnValue(shuffle([
-                {devs: shuffle([oldDevName, firstOtherDevName])},
-                {devs: shuffle([secondOtherDevName, thirdOtherDevName])}
-            ]));
-
-            localStorageService.getSticking.mockReturnValue(shuffle([
-                {devs: shuffle([fourthOtherDevName, firstOtherDevName])},
-                {devs: shuffle([secondOtherDevName, thirdOtherDevName])}
-            ]));
-
-            devService.update(oldDevName, updatedDevName);
-
-            expect(localStorageService.setSticking).not.toHaveBeenCalled();
-        });
+      expect(localStorageService.setDisabled).not.toHaveBeenCalled();
     });
 
-    describe('delete', () => {
-        const devToDelete = faker.unique(faker.name.firstName);
+    it('should not update carrying devs when dev is not carrying', () => {
 
-        const firstOtherDevName = faker.unique(faker.name.firstName);
-        const secondOtherDevName = faker.unique(faker.name.firstName);
-        const thirdOtherDevName = faker.unique(faker.name.firstName);
-        const fourthOtherDevName = faker.unique(faker.name.firstName);
+      localStorageService.getDevs.mockReturnValue(shuffle([
+        oldDevName,
+        firstOtherDevName,
+        secondOtherDevName,
+        thirdOtherDevName,
+        fourthOtherDevName
+      ]));
 
-        it('should remove dev name in every list that contains the dev name', () => {
+      localStorageService.getDisabled.mockReturnValue(shuffle([
+        oldDevName,
+        firstOtherDevName
+      ]));
 
-            localStorageService.getDevs.mockReturnValue(shuffle([
-                devToDelete,
-                firstOtherDevName,
-                secondOtherDevName,
-                thirdOtherDevName,
-                fourthOtherDevName
-            ]));
+      localStorageService.getCarriers.mockReturnValue(shuffle([
+        fourthOtherDevName,
+        secondOtherDevName
+      ]));
 
-            localStorageService.getDisabled.mockReturnValue(shuffle([
-                devToDelete,
-                firstOtherDevName
-            ]));
+      localStorageService.getPairs.mockReturnValue(shuffle([
+        {devs: shuffle([oldDevName, firstOtherDevName])},
+        {devs: shuffle([secondOtherDevName, thirdOtherDevName])}
+      ]));
 
-            localStorageService.getCarriers.mockReturnValue(shuffle([
-                devToDelete,
-                secondOtherDevName
-            ]));
+      localStorageService.getSticking.mockReturnValue(shuffle([
+        {devs: shuffle([oldDevName, firstOtherDevName])},
+        {devs: shuffle([secondOtherDevName, thirdOtherDevName])}
+      ]));
 
-            localStorageService.getPairs.mockReturnValue(shuffle([
-                {devs: shuffle([devToDelete, firstOtherDevName])},
-                {devs: shuffle([secondOtherDevName, thirdOtherDevName])}
-            ]));
+      devService.update(oldDevName, updatedDevName);
 
-            localStorageService.getSticking.mockReturnValue(shuffle([
-                {devs: shuffle([devToDelete, firstOtherDevName])},
-                {devs: shuffle([secondOtherDevName, thirdOtherDevName])}
-            ]));
-
-            devService.delete(devToDelete);
-
-            expect(localStorageService.setDevs).toHaveBeenCalledWith(expect.toIncludeSameMembers([
-                firstOtherDevName,
-                secondOtherDevName,
-                thirdOtherDevName,
-                fourthOtherDevName
-            ]));
-
-            expect(localStorageService.setDisabled).toHaveBeenCalledWith(expect.toIncludeSameMembers([
-                firstOtherDevName
-            ]));
-
-            expect(localStorageService.setCarriers).toHaveBeenCalledWith(expect.toIncludeSameMembers([
-                secondOtherDevName
-            ]));
-
-            expect(localStorageService.setPairs).toHaveBeenCalledWith(expect.toIncludeSameMembers([
-                {devs: expect.toIncludeSameMembers([firstOtherDevName])},
-                {devs: expect.toIncludeSameMembers([secondOtherDevName, thirdOtherDevName])},
-            ]));
-
-            expect(localStorageService.setSticking).toHaveBeenCalledWith(expect.arrayContaining([
-                {devs: expect.toIncludeSameMembers([firstOtherDevName])},
-                {devs: expect.toIncludeSameMembers([secondOtherDevName, thirdOtherDevName])},
-            ]));
-        });
-
-        it('should not update disabled devs when dev is not disabled', () => {
-
-            localStorageService.getDevs.mockReturnValue(shuffle([
-                devToDelete,
-                firstOtherDevName,
-                secondOtherDevName,
-                thirdOtherDevName,
-                fourthOtherDevName
-            ]));
-
-            localStorageService.getDisabled.mockReturnValue(shuffle([
-                fourthOtherDevName,
-                firstOtherDevName
-            ]));
-
-            localStorageService.getCarriers.mockReturnValue(shuffle([
-                devToDelete,
-                secondOtherDevName
-            ]));
-
-            localStorageService.getPairs.mockReturnValue(shuffle([
-                {devs: shuffle([devToDelete, firstOtherDevName])},
-                {devs: shuffle([secondOtherDevName, thirdOtherDevName])}
-            ]));
-
-            localStorageService.getSticking.mockReturnValue(shuffle([
-                {devs: shuffle([devToDelete, firstOtherDevName])},
-                {devs: shuffle([secondOtherDevName, thirdOtherDevName])}
-            ]));
-
-            devService.delete(devToDelete);
-
-            expect(localStorageService.setDisabled).not.toHaveBeenCalled();
-        });
-
-        it('should not update carrying devs when dev is not carrying', () => {
-
-            localStorageService.getDevs.mockReturnValue(shuffle([
-                devToDelete,
-                firstOtherDevName,
-                secondOtherDevName,
-                thirdOtherDevName,
-                fourthOtherDevName
-            ]));
-
-            localStorageService.getDisabled.mockReturnValue(shuffle([
-                devToDelete,
-                firstOtherDevName
-            ]));
-
-            localStorageService.getCarriers.mockReturnValue(shuffle([
-                fourthOtherDevName,
-                secondOtherDevName
-            ]));
-
-            localStorageService.getPairs.mockReturnValue(shuffle([
-                {devs: shuffle([devToDelete, firstOtherDevName])},
-                {devs: shuffle([secondOtherDevName, thirdOtherDevName])}
-            ]));
-
-            localStorageService.getSticking.mockReturnValue(shuffle([
-                {devs: shuffle([devToDelete, firstOtherDevName])},
-                {devs: shuffle([secondOtherDevName, thirdOtherDevName])}
-            ]));
-
-            devService.delete(devToDelete);
-
-            expect(localStorageService.setCarriers).not.toHaveBeenCalled();
-        });
-
-        it('should not update pairs when dev is not paired', () => {
-
-            localStorageService.getDevs.mockReturnValue(shuffle([
-                devToDelete,
-                firstOtherDevName,
-                secondOtherDevName,
-                thirdOtherDevName,
-                fourthOtherDevName
-            ]));
-
-            localStorageService.getDisabled.mockReturnValue(shuffle([
-                devToDelete,
-                firstOtherDevName
-            ]));
-
-            localStorageService.getCarriers.mockReturnValue(shuffle([
-                firstOtherDevName,
-                secondOtherDevName
-            ]));
-
-            localStorageService.getPairs.mockReturnValue(shuffle([
-                {devs: shuffle([fourthOtherDevName, firstOtherDevName])},
-                {devs: shuffle([secondOtherDevName, thirdOtherDevName])}
-            ]));
-
-            localStorageService.getSticking.mockReturnValue(shuffle([
-                {devs: shuffle([devToDelete, firstOtherDevName])},
-                {devs: shuffle([secondOtherDevName, thirdOtherDevName])}
-            ]));
-
-            devService.delete(devToDelete);
-
-            expect(localStorageService.setPairs).not.toHaveBeenCalled();
-        });
-
-        it('should not update sticking pairs when dev is not sticking', () => {
-
-            localStorageService.getDevs.mockReturnValue(shuffle([
-                devToDelete,
-                firstOtherDevName,
-                secondOtherDevName,
-                thirdOtherDevName,
-                fourthOtherDevName
-            ]));
-
-            localStorageService.getDisabled.mockReturnValue(shuffle([
-                devToDelete,
-                firstOtherDevName
-            ]));
-
-            localStorageService.getCarriers.mockReturnValue(shuffle([
-                firstOtherDevName,
-                secondOtherDevName
-            ]));
-
-            localStorageService.getPairs.mockReturnValue(shuffle([
-                {devs: shuffle([devToDelete, firstOtherDevName])},
-                {devs: shuffle([secondOtherDevName, thirdOtherDevName])}
-            ]));
-
-            localStorageService.getSticking.mockReturnValue(shuffle([
-                {devs: shuffle([fourthOtherDevName, firstOtherDevName])},
-                {devs: shuffle([secondOtherDevName, thirdOtherDevName])}
-            ]));
-
-            devService.delete(devToDelete);
-
-            expect(localStorageService.setSticking).not.toHaveBeenCalled();
-        });
+      expect(localStorageService.setCarriers).not.toHaveBeenCalled();
     });
+
+    it('should not update pairs when dev is not paired', () => {
+
+      localStorageService.getDevs.mockReturnValue(shuffle([
+        oldDevName,
+        firstOtherDevName,
+        secondOtherDevName,
+        thirdOtherDevName,
+        fourthOtherDevName
+      ]));
+
+      localStorageService.getDisabled.mockReturnValue(shuffle([
+        oldDevName,
+        firstOtherDevName
+      ]));
+
+      localStorageService.getCarriers.mockReturnValue(shuffle([
+        firstOtherDevName,
+        secondOtherDevName
+      ]));
+
+      localStorageService.getPairs.mockReturnValue(shuffle([
+        {devs: shuffle([fourthOtherDevName, firstOtherDevName])},
+        {devs: shuffle([secondOtherDevName, thirdOtherDevName])}
+      ]));
+
+      localStorageService.getSticking.mockReturnValue(shuffle([
+        {devs: shuffle([oldDevName, firstOtherDevName])},
+        {devs: shuffle([secondOtherDevName, thirdOtherDevName])}
+      ]));
+
+      devService.update(oldDevName, updatedDevName);
+
+      expect(localStorageService.setPairs).not.toHaveBeenCalled();
+    });
+
+    it('should not update sticking pairs when dev is not sticking', () => {
+
+      localStorageService.getDevs.mockReturnValue(shuffle([
+        oldDevName,
+        firstOtherDevName,
+        secondOtherDevName,
+        thirdOtherDevName,
+        fourthOtherDevName
+      ]));
+
+      localStorageService.getDisabled.mockReturnValue(shuffle([
+        oldDevName,
+        firstOtherDevName
+      ]));
+
+      localStorageService.getCarriers.mockReturnValue(shuffle([
+        firstOtherDevName,
+        secondOtherDevName
+      ]));
+
+      localStorageService.getPairs.mockReturnValue(shuffle([
+        {devs: shuffle([oldDevName, firstOtherDevName])},
+        {devs: shuffle([secondOtherDevName, thirdOtherDevName])}
+      ]));
+
+      localStorageService.getSticking.mockReturnValue(shuffle([
+        {devs: shuffle([fourthOtherDevName, firstOtherDevName])},
+        {devs: shuffle([secondOtherDevName, thirdOtherDevName])}
+      ]));
+
+      devService.update(oldDevName, updatedDevName);
+
+      expect(localStorageService.setSticking).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('delete', () => {
+    const devToDelete = faker.unique(faker.name.firstName);
+
+    const firstOtherDevName = faker.unique(faker.name.firstName);
+    const secondOtherDevName = faker.unique(faker.name.firstName);
+    const thirdOtherDevName = faker.unique(faker.name.firstName);
+    const fourthOtherDevName = faker.unique(faker.name.firstName);
+
+    it('should remove dev name in every list that contains the dev name', () => {
+
+      localStorageService.getDevs.mockReturnValue(shuffle([
+        devToDelete,
+        firstOtherDevName,
+        secondOtherDevName,
+        thirdOtherDevName,
+        fourthOtherDevName
+      ]));
+
+      localStorageService.getDisabled.mockReturnValue(shuffle([
+        devToDelete,
+        firstOtherDevName
+      ]));
+
+      localStorageService.getCarriers.mockReturnValue(shuffle([
+        devToDelete,
+        secondOtherDevName
+      ]));
+
+      localStorageService.getPairs.mockReturnValue(shuffle([
+        {devs: shuffle([devToDelete, firstOtherDevName])},
+        {devs: shuffle([secondOtherDevName, thirdOtherDevName])}
+      ]));
+
+      localStorageService.getSticking.mockReturnValue(shuffle([
+        {devs: shuffle([devToDelete, firstOtherDevName])},
+        {devs: shuffle([secondOtherDevName, thirdOtherDevName])}
+      ]));
+
+      devService.delete(devToDelete);
+
+      expect(localStorageService.setDevs).toHaveBeenCalledWith(expect.toIncludeSameMembers([
+        firstOtherDevName,
+        secondOtherDevName,
+        thirdOtherDevName,
+        fourthOtherDevName
+      ]));
+
+      expect(localStorageService.setDisabled).toHaveBeenCalledWith(expect.toIncludeSameMembers([
+        firstOtherDevName
+      ]));
+
+      expect(localStorageService.setCarriers).toHaveBeenCalledWith(expect.toIncludeSameMembers([
+        secondOtherDevName
+      ]));
+
+      expect(localStorageService.setPairs).toHaveBeenCalledWith(expect.toIncludeSameMembers([
+        {devs: expect.toIncludeSameMembers([firstOtherDevName])},
+        {devs: expect.toIncludeSameMembers([secondOtherDevName, thirdOtherDevName])},
+      ]));
+
+      expect(localStorageService.setSticking).toHaveBeenCalledWith(expect.arrayContaining([
+        {devs: expect.toIncludeSameMembers([firstOtherDevName])},
+        {devs: expect.toIncludeSameMembers([secondOtherDevName, thirdOtherDevName])},
+      ]));
+    });
+
+    it('should not update disabled devs when dev is not disabled', () => {
+
+      localStorageService.getDevs.mockReturnValue(shuffle([
+        devToDelete,
+        firstOtherDevName,
+        secondOtherDevName,
+        thirdOtherDevName,
+        fourthOtherDevName
+      ]));
+
+      localStorageService.getDisabled.mockReturnValue(shuffle([
+        fourthOtherDevName,
+        firstOtherDevName
+      ]));
+
+      localStorageService.getCarriers.mockReturnValue(shuffle([
+        devToDelete,
+        secondOtherDevName
+      ]));
+
+      localStorageService.getPairs.mockReturnValue(shuffle([
+        {devs: shuffle([devToDelete, firstOtherDevName])},
+        {devs: shuffle([secondOtherDevName, thirdOtherDevName])}
+      ]));
+
+      localStorageService.getSticking.mockReturnValue(shuffle([
+        {devs: shuffle([devToDelete, firstOtherDevName])},
+        {devs: shuffle([secondOtherDevName, thirdOtherDevName])}
+      ]));
+
+      devService.delete(devToDelete);
+
+      expect(localStorageService.setDisabled).not.toHaveBeenCalled();
+    });
+
+    it('should not update carrying devs when dev is not carrying', () => {
+
+      localStorageService.getDevs.mockReturnValue(shuffle([
+        devToDelete,
+        firstOtherDevName,
+        secondOtherDevName,
+        thirdOtherDevName,
+        fourthOtherDevName
+      ]));
+
+      localStorageService.getDisabled.mockReturnValue(shuffle([
+        devToDelete,
+        firstOtherDevName
+      ]));
+
+      localStorageService.getCarriers.mockReturnValue(shuffle([
+        fourthOtherDevName,
+        secondOtherDevName
+      ]));
+
+      localStorageService.getPairs.mockReturnValue(shuffle([
+        {devs: shuffle([devToDelete, firstOtherDevName])},
+        {devs: shuffle([secondOtherDevName, thirdOtherDevName])}
+      ]));
+
+      localStorageService.getSticking.mockReturnValue(shuffle([
+        {devs: shuffle([devToDelete, firstOtherDevName])},
+        {devs: shuffle([secondOtherDevName, thirdOtherDevName])}
+      ]));
+
+      devService.delete(devToDelete);
+
+      expect(localStorageService.setCarriers).not.toHaveBeenCalled();
+    });
+
+    it('should not update pairs when dev is not paired', () => {
+
+      localStorageService.getDevs.mockReturnValue(shuffle([
+        devToDelete,
+        firstOtherDevName,
+        secondOtherDevName,
+        thirdOtherDevName,
+        fourthOtherDevName
+      ]));
+
+      localStorageService.getDisabled.mockReturnValue(shuffle([
+        devToDelete,
+        firstOtherDevName
+      ]));
+
+      localStorageService.getCarriers.mockReturnValue(shuffle([
+        firstOtherDevName,
+        secondOtherDevName
+      ]));
+
+      localStorageService.getPairs.mockReturnValue(shuffle([
+        {devs: shuffle([fourthOtherDevName, firstOtherDevName])},
+        {devs: shuffle([secondOtherDevName, thirdOtherDevName])}
+      ]));
+
+      localStorageService.getSticking.mockReturnValue(shuffle([
+        {devs: shuffle([devToDelete, firstOtherDevName])},
+        {devs: shuffle([secondOtherDevName, thirdOtherDevName])}
+      ]));
+
+      devService.delete(devToDelete);
+
+      expect(localStorageService.setPairs).not.toHaveBeenCalled();
+    });
+
+    it('should not update sticking pairs when dev is not sticking', () => {
+
+      localStorageService.getDevs.mockReturnValue(shuffle([
+        devToDelete,
+        firstOtherDevName,
+        secondOtherDevName,
+        thirdOtherDevName,
+        fourthOtherDevName
+      ]));
+
+      localStorageService.getDisabled.mockReturnValue(shuffle([
+        devToDelete,
+        firstOtherDevName
+      ]));
+
+      localStorageService.getCarriers.mockReturnValue(shuffle([
+        firstOtherDevName,
+        secondOtherDevName
+      ]));
+
+      localStorageService.getPairs.mockReturnValue(shuffle([
+        {devs: shuffle([devToDelete, firstOtherDevName])},
+        {devs: shuffle([secondOtherDevName, thirdOtherDevName])}
+      ]));
+
+      localStorageService.getSticking.mockReturnValue(shuffle([
+        {devs: shuffle([fourthOtherDevName, firstOtherDevName])},
+        {devs: shuffle([secondOtherDevName, thirdOtherDevName])}
+      ]));
+
+      devService.delete(devToDelete);
+
+      expect(localStorageService.setSticking).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/app/services/rotation.service.spec.ts
+++ b/src/app/services/rotation.service.spec.ts
@@ -1,0 +1,274 @@
+import { RotationService } from './rotation.service';
+import * as faker from 'faker';
+import { Pair } from '../utillity/pair';
+import { arraysAreEqual } from '../utillity/lulz';
+
+describe('RotationService', () => {
+    const localStorageService = {
+        getCarriers: jest.fn(),
+        getDevs: jest.fn(),
+        getBoards: jest.fn(),
+        getDisabled: jest.fn(),
+        getDisabledBoards: jest.fn(),
+        getSticking: jest.fn(),
+        getAllowSolo: jest.fn()
+    };
+
+    const rotationService = new RotationService(localStorageService as any);
+
+    beforeEach(() => {
+        localStorageService.getCarriers.mockReturnValue([]);
+        localStorageService.getDisabled.mockReturnValue([]);
+        localStorageService.getDisabledBoards.mockReturnValue([]);
+        localStorageService.getSticking.mockReturnValue([]);
+        localStorageService.getAllowSolo.mockReturnValue(false);
+    });
+
+    afterEach(() => {
+        jest.resetAllMocks();
+    });
+
+    describe('makeItRotato', () => {
+        it('should return list of randomized pairs', () => {
+            const devs = getDevs(6);
+            const boards = getBoards(3);
+
+            localStorageService.getDevs.mockReturnValue(devs);
+            localStorageService.getBoards.mockReturnValue(boards);
+
+            rotatoValidato((results: Pair[]) => {
+                expect(results).toHaveLength(3);
+                expect(results[0].devs).toHaveLength(2);
+                expect(results[1].devs).toHaveLength(2);
+                expect(results[2].devs).toHaveLength(2);
+
+                const boardsFromResults = [results[0].board, results[1].board, results[2].board];
+                const devsFromResults = [...results[0].devs, ...results[1].devs, ...results[2].devs];
+
+                expect(boardsFromResults).toIncludeSameMembers(boards);
+                expect(devsFromResults).toIncludeSameMembers(devs);
+            }, (allResults: Pair[][]) => verifyAllPairsAreUnique(allResults));
+        });
+
+        it('should not pair carrying devs together when there are carrying devs', () => {
+            const carryingDevs = [getNthDev(1), getNthDev(2), getNthDev(3)];
+            const cleanDevs = [getNthDev(4), getNthDev(5), getNthDev(6)];
+
+            const devs = [...carryingDevs, ...cleanDevs];
+
+            const boards = getBoards(3);
+
+            localStorageService.getDevs.mockReturnValue(devs);
+            localStorageService.getBoards.mockReturnValue(boards);
+            localStorageService.getCarriers.mockReturnValue(carryingDevs);
+
+            rotatoValidato((results: Pair[]) => {
+                const pairHasOneCarryingAndOneClean = (pair: Pair) =>
+                    (carryingDevs.includes(pair.devs[0]) && cleanDevs.includes(pair.devs[1])) ||
+                    (carryingDevs.includes(pair.devs[1]) && cleanDevs.includes(pair.devs[0]));
+
+                expect(results).toSatisfyAll(pairHasOneCarryingAndOneClean);
+            }, (allResults: Pair[][]) => verifyAllPairsAreUnique(allResults));
+        });
+
+        it('should not use disabled devs', () => {
+            const disabledDevs = [getNthDev(1), getNthDev(2)];
+            const enabledDevs = [getNthDev(3), getNthDev(4)];
+
+            const devs = [...disabledDevs, ...enabledDevs];
+
+            localStorageService.getDevs.mockReturnValue(devs);
+            localStorageService.getBoards.mockReturnValue([]);
+            localStorageService.getDisabled.mockReturnValue(disabledDevs);
+
+            const results = rotationService.makeItRotato();
+
+            expect(results).toHaveLength(1);
+            expect(results[0].devs).toIncludeSameMembers(enabledDevs);
+        });
+
+        it('should not use disabled boards', () => {
+            const disabledBoards = [getNthBoard(1), getNthBoard(2)];
+            const enabledBoard = getNthBoard(3);
+
+            const devs = getDevs(6);
+            const boards = [...disabledBoards, enabledBoard];
+
+            localStorageService.getDevs.mockReturnValue(devs);
+            localStorageService.getBoards.mockReturnValue(boards);
+            localStorageService.getDisabledBoards.mockReturnValue(disabledBoards);
+
+            const results = rotationService.makeItRotato();
+
+            expect(results).toHaveLength(3);
+            expect(results[0].devs).toHaveLength(2);
+            expect(results[1].devs).toHaveLength(2);
+            expect(results[2].devs).toHaveLength(2);
+
+            const boardsFromResult = [results[0].board, results[1].board, results[2].board];
+
+            expect(boardsFromResult).toIncludeSameMembers([enabledBoard, undefined, undefined]);
+        });
+
+        it('should make pair without board when not enough boards exist', () => {
+            const devs = getDevs(4);
+            const board = getNthBoard(1);
+
+            localStorageService.getDevs.mockReturnValue(devs);
+            localStorageService.getBoards.mockReturnValue([board]);
+
+            const results = rotationService.makeItRotato();
+
+            const boardsFromResult = [results[0].board, results[1].board];
+            expect(boardsFromResult).toIncludeSameMembers([board, undefined]);
+        });
+
+        it('should keep sticking pairs in the rotated pairs', () => {
+            const firstStickingPair: Pair = {
+                board: getNthBoard(1),
+                devs: [getNthDev(1), getNthDev(2)]
+            };
+
+            const secondStickingPair: Pair = {
+                board: getNthBoard(2),
+                devs: [getNthDev(3), getNthDev(4)]
+            };
+
+            const devs = getDevs(10);
+            const boards = getBoards(5);
+
+            localStorageService.getDevs.mockReturnValue(devs);
+            localStorageService.getBoards.mockReturnValue(boards);
+            localStorageService.getSticking.mockReturnValue([firstStickingPair, secondStickingPair]);
+
+            rotatoValidato((results: Pair[]) => {
+                expect(results).toIncludeAllMembers([firstStickingPair, secondStickingPair]);
+            }, (allResults: Pair[][]) => {
+                const allResultsWithoutStickingPairs = allResults.map(results =>
+                    results.filter(x => x !== firstStickingPair && x !== secondStickingPair)
+                );
+
+                verifyAllPairsAreUnique(allResultsWithoutStickingPairs);
+            });
+        });
+
+        it('should not create empty pairs when there are more boards than devs', () => {
+            const devs = getDevs(2);
+            const boards = getBoards(3);
+
+            localStorageService.getDevs.mockReturnValue(devs);
+            localStorageService.getBoards.mockReturnValue(boards);
+
+            rotatoValidato((results: Pair[]) => {
+                expect(results).toHaveLength(1);
+                expect(results[0].board).toBeOneOf(boards);
+            }, (allResults: Pair[][]) => {
+                const distinctBoards = new Set(allResults.map(results => results[0].board));
+                expect(distinctBoards.size).toBeGreaterThan(1);
+            });
+        });
+
+        describe('when there is an odd number of devs', () => {
+            it('should make a pair of three devs when soloing is not enabled', () => {
+                const devs = getDevs(5);
+                const boards = getBoards(2);
+
+                localStorageService.getDevs.mockReturnValue(devs);
+                localStorageService.getBoards.mockReturnValue(boards);
+
+                rotatoValidato((results: Pair[]) => {
+                    const hasATriplePairAndDoublePair = (pairs: Pair[]) =>
+                        (pairs[0].devs.length === 3 && pairs[1].devs.length === 2) ||
+                        (pairs[0].devs.length === 2 && pairs[1].devs.length === 3);
+
+                    expect(results).toSatisfy(hasATriplePairAndDoublePair);
+                }, (allResults: Pair[][]) => verifyAllPairsAreUnique(allResults));
+            });
+
+            it('should make a pair of one dev when soloing is enabled', () => {
+                const devs = getDevs(5);
+                const boards = getBoards(3);
+
+                localStorageService.getDevs.mockReturnValue(devs);
+                localStorageService.getBoards.mockReturnValue(boards);
+                localStorageService.getAllowSolo.mockReturnValue(true);
+
+                rotatoValidato((results: Pair[]) => {
+                    const pairSizes = results.map(x => x.devs.length);
+
+                    expect(pairSizes).toIncludeSameMembers([2, 2, 1]);
+                }, (allResults: Pair[][]) => verifyAllPairsAreUnique(allResults));
+            });
+        });
+    });
+
+    const testDevData = [];
+    const testBoardData = [];
+
+    function getNthDev(index: number): string {
+        while (testDevData.length < index) {
+            testDevData.push(faker.unique(faker.name.firstName));
+        }
+        return testDevData[index - 1];
+    }
+
+    function getNthBoard(index: number): string {
+        while (testBoardData.length < index) {
+            testBoardData.push(faker.unique(faker.name.firstName));
+        }
+        return testBoardData[index - 1];
+    }
+
+    function getDevs(size: number): string[] {
+        while (testDevData.length < size) {
+            testDevData.push(faker.unique(faker.name.firstName));
+        }
+        return testDevData.slice(0, size);
+    }
+
+    function getBoards(size: number): string[] {
+        while (testBoardData.length < size) {
+            testBoardData.push(faker.unique(faker.name.firstName));
+        }
+        return testBoardData.slice(0, size);
+    }
+
+    function rotatoValidato(
+        expectations: {(results: Pair[])},
+        afterAllExpectations?: {(allResults: Pair[][])}
+    ): void {
+        const numberOfTestRuns = 10;
+
+        const allResults: Pair[][] = [];
+
+        for (let x = 0; x < numberOfTestRuns; x++) {
+            const results = rotationService.makeItRotato();
+            expectations(results);
+            allResults.push(results);
+        }
+
+        if (!!afterAllExpectations) {
+            afterAllExpectations(allResults);
+        }
+    }
+});
+
+function verifyAllPairsAreUnique(allPairs: Pair[][]): void {
+    const allDevPairings = allPairs.map(results => results.map(pair => pair.devs));
+    const repeatedDevPairsInEveryRotation = allDevPairings.reduce((x, y) => getIntersectionOfArrays(x, y));
+
+    expect(repeatedDevPairsInEveryRotation).toHaveLength(0);
+
+    const allDevAndBoardCombos = allPairs.map(results => results.flatMap(pair => pair.devs.map(dev => [dev, pair.board])));
+    const repeatedDevAndBoardCombosInEveryRotation = allDevAndBoardCombos.reduce((x, y) => getIntersectionOfArrays(x, y));
+
+    expect(repeatedDevAndBoardCombosInEveryRotation).toHaveLength(0);
+}
+
+function getIntersectionOfArrays(firstArrays: any[][], secondArrays: any[][]): any[][] {
+    return firstArrays.filter(firstArray =>
+        secondArrays.find(secondArray =>
+            arraysAreEqual(firstArray, secondArray)
+        )
+    );
+}

--- a/src/app/services/rotation.service.spec.ts
+++ b/src/app/services/rotation.service.spec.ts
@@ -4,439 +4,439 @@ import { Pair } from '../utillity/pair';
 import { arraysAreEqual } from '../utillity/lulz';
 
 describe('RotationService', () => {
-    const localStorageService = {
-        getCarriers: jest.fn(),
-        getDevs: jest.fn(),
-        getBoards: jest.fn(),
-        getDisabled: jest.fn(),
-        getDisabledBoards: jest.fn(),
-        getSticking: jest.fn(),
-        getAllowSolo: jest.fn(),
-        getPairs: jest.fn()
-    };
+  const localStorageService = {
+    getCarriers: jest.fn(),
+    getDevs: jest.fn(),
+    getBoards: jest.fn(),
+    getDisabled: jest.fn(),
+    getDisabledBoards: jest.fn(),
+    getSticking: jest.fn(),
+    getAllowSolo: jest.fn(),
+    getPairs: jest.fn()
+  };
 
-    const rotationService = new RotationService(localStorageService as any);
+  const rotationService = new RotationService(localStorageService as any);
 
-    beforeEach(() => {
-        localStorageService.getCarriers.mockReturnValue([]);
-        localStorageService.getDisabled.mockReturnValue([]);
-        localStorageService.getDisabledBoards.mockReturnValue([]);
-        localStorageService.getSticking.mockReturnValue([]);
-        localStorageService.getAllowSolo.mockReturnValue(false);
-        localStorageService.getPairs.mockReturnValue([]);
+  beforeEach(() => {
+    localStorageService.getCarriers.mockReturnValue([]);
+    localStorageService.getDisabled.mockReturnValue([]);
+    localStorageService.getDisabledBoards.mockReturnValue([]);
+    localStorageService.getSticking.mockReturnValue([]);
+    localStorageService.getAllowSolo.mockReturnValue(false);
+    localStorageService.getPairs.mockReturnValue([]);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('makeItRotato', () => {
+    it('should return list of randomized pairs', () => {
+      const devs = getDevs(6);
+      const boards = getBoards(3);
+
+      localStorageService.getDevs.mockReturnValue(devs);
+      localStorageService.getBoards.mockReturnValue(boards);
+
+      rotatoValidato((results: Pair[]) => {
+        expect(results).toHaveLength(3);
+        expect(results).toSatisfyAll(pairHasTwoDevs);
+        verifyPairsContainDevsAndBoards(results, devs, boards);
+      }, (allResults: Pair[][]) => verifyAllPairsAreUnique(allResults));
     });
 
-    afterEach(() => {
-        jest.resetAllMocks();
+    it('should not pair carrying devs together when there are carrying devs', () => {
+      const carryingDevs = [getNthDev(1), getNthDev(2), getNthDev(3)];
+      const cleanDevs = [getNthDev(4), getNthDev(5), getNthDev(6)];
+
+      const devs = [...carryingDevs, ...cleanDevs];
+
+      const boards = getBoards(3);
+
+      localStorageService.getDevs.mockReturnValue(devs);
+      localStorageService.getBoards.mockReturnValue(boards);
+      localStorageService.getCarriers.mockReturnValue(carryingDevs);
+
+      rotatoValidato((results: Pair[]) => {
+        expect(results).toHaveLength(3);
+        expect(results).toSatisfyAll(pairHasTwoDevs);
+        verifyPairsContainDevsAndBoards(results, devs, boards);
+
+        const pairHasOneCarryingAndOneClean = (pair: Pair) =>
+          (carryingDevs.includes(pair.devs[0]) && cleanDevs.includes(pair.devs[1])) ||
+          (carryingDevs.includes(pair.devs[1]) && cleanDevs.includes(pair.devs[0]));
+
+        expect(results).toSatisfyAll(pairHasOneCarryingAndOneClean);
+      }, (allResults: Pair[][]) => verifyAllPairsAreUnique(allResults));
     });
 
-    describe('makeItRotato', () => {
-        it('should return list of randomized pairs', () => {
-            const devs = getDevs(6);
-            const boards = getBoards(3);
-
-            localStorageService.getDevs.mockReturnValue(devs);
-            localStorageService.getBoards.mockReturnValue(boards);
-
-            rotatoValidato((results: Pair[]) => {
-                expect(results).toHaveLength(3);
-                expect(results).toSatisfyAll(pairHasTwoDevs);
-                verifyPairsContainDevsAndBoards(results, devs, boards);
-            }, (allResults: Pair[][]) => verifyAllPairsAreUnique(allResults));
-        });
-
-        it('should not pair carrying devs together when there are carrying devs', () => {
-            const carryingDevs = [getNthDev(1), getNthDev(2), getNthDev(3)];
-            const cleanDevs = [getNthDev(4), getNthDev(5), getNthDev(6)];
-
-            const devs = [...carryingDevs, ...cleanDevs];
-
-            const boards = getBoards(3);
-
-            localStorageService.getDevs.mockReturnValue(devs);
-            localStorageService.getBoards.mockReturnValue(boards);
-            localStorageService.getCarriers.mockReturnValue(carryingDevs);
-
-            rotatoValidato((results: Pair[]) => {
-                expect(results).toHaveLength(3);
-                expect(results).toSatisfyAll(pairHasTwoDevs);
-                verifyPairsContainDevsAndBoards(results, devs, boards);
-
-                const pairHasOneCarryingAndOneClean = (pair: Pair) =>
-                    (carryingDevs.includes(pair.devs[0]) && cleanDevs.includes(pair.devs[1])) ||
-                    (carryingDevs.includes(pair.devs[1]) && cleanDevs.includes(pair.devs[0]));
-
-                expect(results).toSatisfyAll(pairHasOneCarryingAndOneClean);
-            }, (allResults: Pair[][]) => verifyAllPairsAreUnique(allResults));
-        });
-
-        it('should make a solo pair when there are more carriers than clean devs', () => {
-            const carryingDevs = [getNthDev(1), getNthDev(2)];
-            
-            const devs = getDevs(3);
-            const boards = getBoards(2);
-
-            localStorageService.getDevs.mockReturnValue(devs);
-            localStorageService.getBoards.mockReturnValue(boards);
-            localStorageService.getCarriers.mockReturnValue(carryingDevs);
-
-            rotatoValidato((results: Pair[]) => {
-                verifyPairsContainDevsAndBoards(results, devs, boards);
-
-                const pairSizes = results.map(x => x.devs.length);
-                expect(pairSizes).toIncludeSameMembers([2, 1]);
-
-                const oneCarrierIsSolo = (pairs: Pair[]) =>
-                    (pairs[0].devs.length === 1 && carryingDevs.includes(pairs[0].devs[0])) ||
-                    (pairs[1].devs.length === 1 && carryingDevs.includes(pairs[0].devs[0]));
-                expect(results).toSatisfy(oneCarrierIsSolo);
-            }, (allResults: Pair[][]) => verifyAllPairsAreUnique(allResults));
-        });
-
-        it('should not use disabled devs', () => {
-            const disabledDevs = [getNthDev(1), getNthDev(2)];
-            const enabledDevs = [getNthDev(3), getNthDev(4)];
-
-            const devs = [...disabledDevs, ...enabledDevs];
-
-            localStorageService.getDevs.mockReturnValue(devs);
-            localStorageService.getBoards.mockReturnValue([]);
-            localStorageService.getDisabled.mockReturnValue(disabledDevs);
-
-            const results = rotationService.makeItRotato();
-
-            expect(results).toHaveLength(1);
-            expect(results[0].devs).toIncludeSameMembers(enabledDevs);
-        });
-
-        it('should not use disabled boards', () => {
-            const disabledBoards = [getNthBoard(1), getNthBoard(2)];
-            const enabledBoard = getNthBoard(3);
-
-            const devs = getDevs(6);
-            const boards = [...disabledBoards, enabledBoard];
-
-            localStorageService.getDevs.mockReturnValue(devs);
-            localStorageService.getBoards.mockReturnValue(boards);
-            localStorageService.getDisabledBoards.mockReturnValue(disabledBoards);
-
-            const results = rotationService.makeItRotato();
-
-            expect(results).toHaveLength(3);
-            expect(results).toSatisfyAll(pairHasTwoDevs);
-            verifyPairsContainDevsAndBoards(results, devs, [enabledBoard, undefined, undefined]);
-        });
-
-        it('should make pair without board when not enough boards exist', () => {
-            const devs = getDevs(4);
-            const board = getNthBoard(1);
-
-            localStorageService.getDevs.mockReturnValue(devs);
-            localStorageService.getBoards.mockReturnValue([board]);
-
-            const results = rotationService.makeItRotato();
-
-            expect(results).toHaveLength(2);
-            expect(results).toSatisfyAll(pairHasTwoDevs);
-            verifyPairsContainDevsAndBoards(results, devs, [board, undefined]);
-        });
-
-        it('should keep sticking pairs in the rotated pairs', () => {
-            const firstStickingPair: Pair = {
-                board: getNthBoard(1),
-                devs: [getNthDev(1), getNthDev(2)]
-            };
-
-            const secondStickingPair: Pair = {
-                board: getNthBoard(2),
-                devs: [getNthDev(3), getNthDev(4)]
-            };
-
-            const devs = getDevs(10);
-            const boards = getBoards(5);
-
-            localStorageService.getDevs.mockReturnValue(devs);
-            localStorageService.getBoards.mockReturnValue(boards);
-            localStorageService.getSticking.mockReturnValue([firstStickingPair, secondStickingPair]);
-
-            rotatoValidato((results: Pair[]) => {
-                expect(results).toHaveLength(5);
-                expect(results).toSatisfyAll(pairHasTwoDevs);
-                verifyPairsContainDevsAndBoards(results, devs, boards);
-
-                expect(results).toIncludeAllMembers([firstStickingPair, secondStickingPair]);
-
-            }, (allResults: Pair[][]) => {
-                const allResultsWithoutStickingPairs = allResults.map(results =>
-                    results.filter(x => x !== firstStickingPair && x !== secondStickingPair)
-                );
-
-                verifyAllPairsAreUnique(allResultsWithoutStickingPairs);
-            });
-        });
-
-        it('should not create empty pairs when there are more boards than devs', () => {
-            const devs = getDevs(2);
-            const boards = getBoards(3);
-
-            localStorageService.getDevs.mockReturnValue(devs);
-            localStorageService.getBoards.mockReturnValue(boards);
-
-            rotatoValidato((results: Pair[]) => {
-                expect(results).toHaveLength(1);
-                expect(results[0].devs).toIncludeSameMembers(devs);
-                expect(results[0].board).toBeOneOf(boards);
-            }, (allResults: Pair[][]) => {
-                const distinctBoards = new Set(allResults.map(results => results[0].board));
-                expect(distinctBoards.size).toBeGreaterThan(1);
-            });
-        });
-
-        describe('when there is an odd number of devs', () => {
-            it('should make a pair of three devs when soloing is not enabled', () => {
-                const devs = getDevs(5);
-                const boards = getBoards(2);
-
-                localStorageService.getDevs.mockReturnValue(devs);
-                localStorageService.getBoards.mockReturnValue(boards);
-
-                rotatoValidato((results: Pair[]) => {
-                    expect(results).toHaveLength(2);
-                    verifyPairsContainDevsAndBoards(results, devs, boards);
-
-                    const hasATriplePairAndDoublePair = (pairs: Pair[]) =>
-                        (pairs[0].devs.length === 3 && pairs[1].devs.length === 2) ||
-                        (pairs[0].devs.length === 2 && pairs[1].devs.length === 3);
-
-                    expect(results).toSatisfy(hasATriplePairAndDoublePair);
-                }, (allResults: Pair[][]) => verifyAllPairsAreUnique(allResults));
-            });
-
-            it('should make a pair of one dev when soloing is enabled', () => {
-                const devs = getDevs(5);
-                const boards = getBoards(3);
-
-                localStorageService.getDevs.mockReturnValue(devs);
-                localStorageService.getBoards.mockReturnValue(boards);
-                localStorageService.getAllowSolo.mockReturnValue(true);
-
-                rotatoValidato((results: Pair[]) => {
-                    verifyPairsContainDevsAndBoards(results, devs, boards);
-
-                    const pairSizes = results.map(x => x.devs.length);
-                    expect(pairSizes).toIncludeSameMembers([2, 2, 1]);
-                }, (allResults: Pair[][]) => verifyAllPairsAreUnique(allResults));
-            });
-        });
-
-        describe('when there are carrying devs from previous rotation', () => {
-            it('should keep carrying dev on the same board', () => {
-                const carryingDev = getNthDev(1);
-                const carryingBoard = getNthBoard(1);
-
-                const previousPairs: Pair[] = [
-                    {board: carryingBoard, devs: [carryingDev, getNthDev(2)]},
-                    {board: getNthBoard(2), devs: [getNthDev(3), getNthDev(4)]}
-                ]
-
-                const devs = getDevs(6);
-                const boards = getBoards(3);
-
-                localStorageService.getDevs.mockReturnValue(devs);
-                localStorageService.getBoards.mockReturnValue(boards);
-                localStorageService.getCarriers.mockReturnValue([carryingDev]);
-                localStorageService.getPairs.mockReturnValue(previousPairs);
-
-                rotatoValidato((results: Pair[]) => {
-                    expect(results).toHaveLength(3);
-                    expect(results).toSatisfyAll(pairHasTwoDevs);
-                    verifyPairsContainDevsAndBoards(results, devs, boards);
-
-                    const carryingDevIsOnTheSameBoard = (pairs: Pair[]) =>
-                        (pairs[0].devs.includes(carryingDev) && pairs[0].board === carryingBoard) ||
-                        (pairs[1].devs.includes(carryingDev) && pairs[1].board === carryingBoard) ||
-                        (pairs[2].devs.includes(carryingDev) && pairs[2].board === carryingBoard);
-
-                    expect(results).toSatisfy(carryingDevIsOnTheSameBoard);
-                }, (allResults: Pair[][]) => {
-                    const allDevsThatPairedWithCarryingDev = new Set(allResults.map(results => 
-                        results.filter(pair => pair.devs.includes(carryingDev))[0].devs
-                            .filter(dev => dev !== carryingDev)[0]
-                    ));
-                    expect(allDevsThatPairedWithCarryingDev.size).toBeGreaterThan(1);
-
-                    const allResultsWithoutCarryingPair = allResults.map(results => results.filter(pair => !pair.devs.includes(carryingDev)));
-                    verifyAllPairsAreUnique(allResultsWithoutCarryingPair);
-                });
-            });
-
-            it('should keep carrying devs paired together when two devs are carrying one board', () => {
-                const firstCarryingDev = getNthDev(1);
-                const secondCarryingDev = getNthDev(2);
-                const carryingBoard = getNthBoard(1);
-
-                const carryingPair: Pair = {board: carryingBoard, devs: [firstCarryingDev, secondCarryingDev]};
-
-                const previousPairs: Pair[] = [
-                    carryingPair,
-                    {board: getNthBoard(2), devs: [getNthDev(3), getNthDev(4)]}
-                ]
-
-                const devs = getDevs(6);
-                const boards = getBoards(3);
-
-                localStorageService.getDevs.mockReturnValue(devs);
-                localStorageService.getBoards.mockReturnValue(boards);
-                localStorageService.getCarriers.mockReturnValue([firstCarryingDev, secondCarryingDev]);
-                localStorageService.getPairs.mockReturnValue(previousPairs);
-
-                rotatoValidato((results: Pair[]) => {
-                    expect(results).toHaveLength(3);
-                    expect(results).toSatisfyAll(pairHasTwoDevs);
-                    verifyPairsContainDevsAndBoards(results, devs, boards);
-
-                    expect(carryingPair).toBeOneOf(results);
-                }, (allResults: Pair[][]) => {
-                    const allResultsWithoutCarryingPair = allResults.map(results =>
-                        results.filter(pair => pair == carryingPair)
-                    );
-                    verifyAllPairsAreUnique(allResultsWithoutCarryingPair);
-                });
-            });
-
-            it('should put carrying pair on a new board when previous pair board is disabled', () => {
-                const disabledCarryingBoard = getNthBoard(1);
-                const firstOtherBoard = getNthBoard(2);
-                const secondOtherBoard = getNthBoard(3);
-
-                const carryingDev = getNthDev(1);
-
-                const carryingPair: Pair = {board: disabledCarryingBoard, devs: [carryingDev, getNthDev(2)]};
-
-                const devs = getDevs(2);
-
-                const boards = [
-                    disabledCarryingBoard,
-                    firstOtherBoard,
-                    secondOtherBoard
-                ]
-                
-                localStorageService.getDevs.mockReturnValue(devs);
-                localStorageService.getBoards.mockReturnValue(boards);
-                localStorageService.getCarriers.mockReturnValue([carryingDev]);
-                localStorageService.getDisabledBoards.mockReturnValue([disabledCarryingBoard]);
-                localStorageService.getPairs.mockReturnValue([carryingPair]);
-
-                rotatoValidato((results: Pair[]) => {
-                    expect(results).toHaveLength(1);
-                    expect(results[0].devs).toIncludeSameMembers(devs);
-                    expect(results[0].board).toBeOneOf([firstOtherBoard, secondOtherBoard]);
-                }, (allResults: Pair[][]) => {
-                    const distinctBoards = new Set(allResults.map(results => results[0].board));
-                    expect(distinctBoards.size).toBeGreaterThan(1);
-                });
-            });
-
-            it('should ignore carrying devs when carrying devs are sticking from the previous rotation', () => {
-                const stickingCarryingDev = getNthDev(1);
-                const stickingPair: Pair = {board: undefined, devs: [stickingCarryingDev, getNthDev(2)]};
-    
-                const devs = getDevs(4);
-    
-                localStorageService.getDevs.mockReturnValue(devs);
-                localStorageService.getBoards.mockReturnValue([]);
-                localStorageService.getCarriers.mockReturnValue([stickingCarryingDev]);
-                localStorageService.getSticking.mockReturnValue([stickingPair]);
-                localStorageService.getPairs.mockReturnValue([stickingPair, {devs: [getNthDev(3), getNthDev(4)]}])
-    
-                const results = rotationService.makeItRotato();
-    
-                expect(results).toHaveLength(2);
-                expect(results).toSatisfyAll(pairHasTwoDevs);
-                verifyPairsContainDevsAndBoards(results, devs, [undefined, undefined]);
-    
-                expect(stickingPair).toBeOneOf(results);
-            });
-        });
+    it('should make a solo pair when there are more carriers than clean devs', () => {
+      const carryingDevs = [getNthDev(1), getNthDev(2)];
+      
+      const devs = getDevs(3);
+      const boards = getBoards(2);
+
+      localStorageService.getDevs.mockReturnValue(devs);
+      localStorageService.getBoards.mockReturnValue(boards);
+      localStorageService.getCarriers.mockReturnValue(carryingDevs);
+
+      rotatoValidato((results: Pair[]) => {
+        verifyPairsContainDevsAndBoards(results, devs, boards);
+
+        const pairSizes = results.map(x => x.devs.length);
+        expect(pairSizes).toIncludeSameMembers([2, 1]);
+
+        const oneCarrierIsSolo = (pairs: Pair[]) =>
+          (pairs[0].devs.length === 1 && carryingDevs.includes(pairs[0].devs[0])) ||
+          (pairs[1].devs.length === 1 && carryingDevs.includes(pairs[0].devs[0]));
+        expect(results).toSatisfy(oneCarrierIsSolo);
+      }, (allResults: Pair[][]) => verifyAllPairsAreUnique(allResults));
     });
 
-    const testDevData = [];
-    const testBoardData = [];
+    it('should not use disabled devs', () => {
+      const disabledDevs = [getNthDev(1), getNthDev(2)];
+      const enabledDevs = [getNthDev(3), getNthDev(4)];
 
-    function getNthDev(index: number): string {
-        while (testDevData.length < index) {
-            testDevData.push(faker.unique(faker.name.firstName));
-        }
-        return testDevData[index - 1];
+      const devs = [...disabledDevs, ...enabledDevs];
+
+      localStorageService.getDevs.mockReturnValue(devs);
+      localStorageService.getBoards.mockReturnValue([]);
+      localStorageService.getDisabled.mockReturnValue(disabledDevs);
+
+      const results = rotationService.makeItRotato();
+
+      expect(results).toHaveLength(1);
+      expect(results[0].devs).toIncludeSameMembers(enabledDevs);
+    });
+
+    it('should not use disabled boards', () => {
+      const disabledBoards = [getNthBoard(1), getNthBoard(2)];
+      const enabledBoard = getNthBoard(3);
+
+      const devs = getDevs(6);
+      const boards = [...disabledBoards, enabledBoard];
+
+      localStorageService.getDevs.mockReturnValue(devs);
+      localStorageService.getBoards.mockReturnValue(boards);
+      localStorageService.getDisabledBoards.mockReturnValue(disabledBoards);
+
+      const results = rotationService.makeItRotato();
+
+      expect(results).toHaveLength(3);
+      expect(results).toSatisfyAll(pairHasTwoDevs);
+      verifyPairsContainDevsAndBoards(results, devs, [enabledBoard, undefined, undefined]);
+    });
+
+    it('should make pair without board when not enough boards exist', () => {
+      const devs = getDevs(4);
+      const board = getNthBoard(1);
+
+      localStorageService.getDevs.mockReturnValue(devs);
+      localStorageService.getBoards.mockReturnValue([board]);
+
+      const results = rotationService.makeItRotato();
+
+      expect(results).toHaveLength(2);
+      expect(results).toSatisfyAll(pairHasTwoDevs);
+      verifyPairsContainDevsAndBoards(results, devs, [board, undefined]);
+    });
+
+    it('should keep sticking pairs in the rotated pairs', () => {
+      const firstStickingPair: Pair = {
+        board: getNthBoard(1),
+        devs: [getNthDev(1), getNthDev(2)]
+      };
+
+      const secondStickingPair: Pair = {
+        board: getNthBoard(2),
+        devs: [getNthDev(3), getNthDev(4)]
+      };
+
+      const devs = getDevs(10);
+      const boards = getBoards(5);
+
+      localStorageService.getDevs.mockReturnValue(devs);
+      localStorageService.getBoards.mockReturnValue(boards);
+      localStorageService.getSticking.mockReturnValue([firstStickingPair, secondStickingPair]);
+
+      rotatoValidato((results: Pair[]) => {
+        expect(results).toHaveLength(5);
+        expect(results).toSatisfyAll(pairHasTwoDevs);
+        verifyPairsContainDevsAndBoards(results, devs, boards);
+
+        expect(results).toIncludeAllMembers([firstStickingPair, secondStickingPair]);
+
+      }, (allResults: Pair[][]) => {
+        const allResultsWithoutStickingPairs = allResults.map(results =>
+          results.filter(x => x !== firstStickingPair && x !== secondStickingPair)
+        );
+
+        verifyAllPairsAreUnique(allResultsWithoutStickingPairs);
+      });
+    });
+
+    it('should not create empty pairs when there are more boards than devs', () => {
+      const devs = getDevs(2);
+      const boards = getBoards(3);
+
+      localStorageService.getDevs.mockReturnValue(devs);
+      localStorageService.getBoards.mockReturnValue(boards);
+
+      rotatoValidato((results: Pair[]) => {
+        expect(results).toHaveLength(1);
+        expect(results[0].devs).toIncludeSameMembers(devs);
+        expect(results[0].board).toBeOneOf(boards);
+      }, (allResults: Pair[][]) => {
+        const distinctBoards = new Set(allResults.map(results => results[0].board));
+        expect(distinctBoards.size).toBeGreaterThan(1);
+      });
+    });
+
+    describe('when there is an odd number of devs', () => {
+      it('should make a pair of three devs when soloing is not enabled', () => {
+        const devs = getDevs(5);
+        const boards = getBoards(2);
+
+        localStorageService.getDevs.mockReturnValue(devs);
+        localStorageService.getBoards.mockReturnValue(boards);
+
+        rotatoValidato((results: Pair[]) => {
+          expect(results).toHaveLength(2);
+          verifyPairsContainDevsAndBoards(results, devs, boards);
+
+          const hasATriplePairAndDoublePair = (pairs: Pair[]) =>
+            (pairs[0].devs.length === 3 && pairs[1].devs.length === 2) ||
+            (pairs[0].devs.length === 2 && pairs[1].devs.length === 3);
+
+          expect(results).toSatisfy(hasATriplePairAndDoublePair);
+        }, (allResults: Pair[][]) => verifyAllPairsAreUnique(allResults));
+      });
+
+      it('should make a pair of one dev when soloing is enabled', () => {
+        const devs = getDevs(5);
+        const boards = getBoards(3);
+
+        localStorageService.getDevs.mockReturnValue(devs);
+        localStorageService.getBoards.mockReturnValue(boards);
+        localStorageService.getAllowSolo.mockReturnValue(true);
+
+        rotatoValidato((results: Pair[]) => {
+          verifyPairsContainDevsAndBoards(results, devs, boards);
+
+          const pairSizes = results.map(x => x.devs.length);
+          expect(pairSizes).toIncludeSameMembers([2, 2, 1]);
+        }, (allResults: Pair[][]) => verifyAllPairsAreUnique(allResults));
+      });
+    });
+
+    describe('when there are carrying devs from previous rotation', () => {
+      it('should keep carrying dev on the same board', () => {
+        const carryingDev = getNthDev(1);
+        const carryingBoard = getNthBoard(1);
+
+        const previousPairs: Pair[] = [
+          {board: carryingBoard, devs: [carryingDev, getNthDev(2)]},
+          {board: getNthBoard(2), devs: [getNthDev(3), getNthDev(4)]}
+        ]
+
+        const devs = getDevs(6);
+        const boards = getBoards(3);
+
+        localStorageService.getDevs.mockReturnValue(devs);
+        localStorageService.getBoards.mockReturnValue(boards);
+        localStorageService.getCarriers.mockReturnValue([carryingDev]);
+        localStorageService.getPairs.mockReturnValue(previousPairs);
+
+        rotatoValidato((results: Pair[]) => {
+          expect(results).toHaveLength(3);
+          expect(results).toSatisfyAll(pairHasTwoDevs);
+          verifyPairsContainDevsAndBoards(results, devs, boards);
+
+          const carryingDevIsOnTheSameBoard = (pairs: Pair[]) =>
+            (pairs[0].devs.includes(carryingDev) && pairs[0].board === carryingBoard) ||
+            (pairs[1].devs.includes(carryingDev) && pairs[1].board === carryingBoard) ||
+            (pairs[2].devs.includes(carryingDev) && pairs[2].board === carryingBoard);
+
+          expect(results).toSatisfy(carryingDevIsOnTheSameBoard);
+        }, (allResults: Pair[][]) => {
+          const allDevsThatPairedWithCarryingDev = new Set(allResults.map(results => 
+            results.filter(pair => pair.devs.includes(carryingDev))[0].devs
+              .filter(dev => dev !== carryingDev)[0]
+          ));
+          expect(allDevsThatPairedWithCarryingDev.size).toBeGreaterThan(1);
+
+          const allResultsWithoutCarryingPair = allResults.map(results => results.filter(pair => !pair.devs.includes(carryingDev)));
+          verifyAllPairsAreUnique(allResultsWithoutCarryingPair);
+        });
+      });
+
+      it('should keep carrying devs paired together when two devs are carrying one board', () => {
+        const firstCarryingDev = getNthDev(1);
+        const secondCarryingDev = getNthDev(2);
+        const carryingBoard = getNthBoard(1);
+
+        const carryingPair: Pair = {board: carryingBoard, devs: [firstCarryingDev, secondCarryingDev]};
+
+        const previousPairs: Pair[] = [
+          carryingPair,
+          {board: getNthBoard(2), devs: [getNthDev(3), getNthDev(4)]}
+        ]
+
+        const devs = getDevs(6);
+        const boards = getBoards(3);
+
+        localStorageService.getDevs.mockReturnValue(devs);
+        localStorageService.getBoards.mockReturnValue(boards);
+        localStorageService.getCarriers.mockReturnValue([firstCarryingDev, secondCarryingDev]);
+        localStorageService.getPairs.mockReturnValue(previousPairs);
+
+        rotatoValidato((results: Pair[]) => {
+          expect(results).toHaveLength(3);
+          expect(results).toSatisfyAll(pairHasTwoDevs);
+          verifyPairsContainDevsAndBoards(results, devs, boards);
+
+          expect(carryingPair).toBeOneOf(results);
+        }, (allResults: Pair[][]) => {
+          const allResultsWithoutCarryingPair = allResults.map(results =>
+            results.filter(pair => pair == carryingPair)
+          );
+          verifyAllPairsAreUnique(allResultsWithoutCarryingPair);
+        });
+      });
+
+      it('should put carrying pair on a new board when previous pair board is disabled', () => {
+        const disabledCarryingBoard = getNthBoard(1);
+        const firstOtherBoard = getNthBoard(2);
+        const secondOtherBoard = getNthBoard(3);
+
+        const carryingDev = getNthDev(1);
+
+        const carryingPair: Pair = {board: disabledCarryingBoard, devs: [carryingDev, getNthDev(2)]};
+
+        const devs = getDevs(2);
+
+        const boards = [
+          disabledCarryingBoard,
+          firstOtherBoard,
+          secondOtherBoard
+        ]
+        
+        localStorageService.getDevs.mockReturnValue(devs);
+        localStorageService.getBoards.mockReturnValue(boards);
+        localStorageService.getCarriers.mockReturnValue([carryingDev]);
+        localStorageService.getDisabledBoards.mockReturnValue([disabledCarryingBoard]);
+        localStorageService.getPairs.mockReturnValue([carryingPair]);
+
+        rotatoValidato((results: Pair[]) => {
+          expect(results).toHaveLength(1);
+          expect(results[0].devs).toIncludeSameMembers(devs);
+          expect(results[0].board).toBeOneOf([firstOtherBoard, secondOtherBoard]);
+        }, (allResults: Pair[][]) => {
+          const distinctBoards = new Set(allResults.map(results => results[0].board));
+          expect(distinctBoards.size).toBeGreaterThan(1);
+        });
+      });
+
+      it('should ignore carrying devs when carrying devs are sticking from the previous rotation', () => {
+        const stickingCarryingDev = getNthDev(1);
+        const stickingPair: Pair = {board: undefined, devs: [stickingCarryingDev, getNthDev(2)]};
+  
+        const devs = getDevs(4);
+  
+        localStorageService.getDevs.mockReturnValue(devs);
+        localStorageService.getBoards.mockReturnValue([]);
+        localStorageService.getCarriers.mockReturnValue([stickingCarryingDev]);
+        localStorageService.getSticking.mockReturnValue([stickingPair]);
+        localStorageService.getPairs.mockReturnValue([stickingPair, {devs: [getNthDev(3), getNthDev(4)]}])
+  
+        const results = rotationService.makeItRotato();
+  
+        expect(results).toHaveLength(2);
+        expect(results).toSatisfyAll(pairHasTwoDevs);
+        verifyPairsContainDevsAndBoards(results, devs, [undefined, undefined]);
+  
+        expect(stickingPair).toBeOneOf(results);
+      });
+    });
+  });
+
+  const testDevData = [];
+  const testBoardData = [];
+
+  function getNthDev(index: number): string {
+    while (testDevData.length < index) {
+      testDevData.push(faker.unique(faker.name.firstName));
+    }
+    return testDevData[index - 1];
+  }
+
+  function getNthBoard(index: number): string {
+    while (testBoardData.length < index) {
+      testBoardData.push(faker.unique(faker.name.firstName));
+    }
+    return testBoardData[index - 1];
+  }
+
+  function getDevs(size: number): string[] {
+    while (testDevData.length < size) {
+      testDevData.push(faker.unique(faker.name.firstName));
+    }
+    return testDevData.slice(0, size);
+  }
+
+  function getBoards(size: number): string[] {
+    while (testBoardData.length < size) {
+      testBoardData.push(faker.unique(faker.name.firstName));
+    }
+    return testBoardData.slice(0, size);
+  }
+
+  function rotatoValidato(
+    expectations: {(results: Pair[])},
+    afterAllExpectations?: {(allResults: Pair[][])}
+  ): void {
+    const numberOfTestRuns = 10;
+
+    const allResults: Pair[][] = [];
+
+    for (let x = 0; x < numberOfTestRuns; x++) {
+      const results = rotationService.makeItRotato();
+      expectations(results);
+      allResults.push(results);
     }
 
-    function getNthBoard(index: number): string {
-        while (testBoardData.length < index) {
-            testBoardData.push(faker.unique(faker.name.firstName));
-        }
-        return testBoardData[index - 1];
+    if (!!afterAllExpectations) {
+      afterAllExpectations(allResults);
     }
-
-    function getDevs(size: number): string[] {
-        while (testDevData.length < size) {
-            testDevData.push(faker.unique(faker.name.firstName));
-        }
-        return testDevData.slice(0, size);
-    }
-
-    function getBoards(size: number): string[] {
-        while (testBoardData.length < size) {
-            testBoardData.push(faker.unique(faker.name.firstName));
-        }
-        return testBoardData.slice(0, size);
-    }
-
-    function rotatoValidato(
-        expectations: {(results: Pair[])},
-        afterAllExpectations?: {(allResults: Pair[][])}
-    ): void {
-        const numberOfTestRuns = 10;
-
-        const allResults: Pair[][] = [];
-
-        for (let x = 0; x < numberOfTestRuns; x++) {
-            const results = rotationService.makeItRotato();
-            expectations(results);
-            allResults.push(results);
-        }
-
-        if (!!afterAllExpectations) {
-            afterAllExpectations(allResults);
-        }
-    }
+  }
 });
 
 const pairHasTwoDevs = (pair: Pair) => pair.devs.length === 2;
 
 function verifyPairsContainDevsAndBoards(pairs: Pair[], expectedDevs: string[], expectedBoards: string[]) {
-    const devs = pairs.flatMap(pair => pair.devs);
-    expect(devs).toIncludeSameMembers(expectedDevs);
+  const devs = pairs.flatMap(pair => pair.devs);
+  expect(devs).toIncludeSameMembers(expectedDevs);
 
-    const boards = pairs.map(pair => pair.board);
-    expect(boards).toIncludeSameMembers(expectedBoards);
+  const boards = pairs.map(pair => pair.board);
+  expect(boards).toIncludeSameMembers(expectedBoards);
 }
 
 function verifyAllPairsAreUnique(allPairs: Pair[][]): void {
-    const allDevPairings = allPairs.map(results => results.map(pair => pair.devs));
-    const repeatedDevPairsInEveryRotation = allDevPairings.reduce((x, y) => getIntersectionOfArrays(x, y));
+  const allDevPairings = allPairs.map(results => results.map(pair => pair.devs));
+  const repeatedDevPairsInEveryRotation = allDevPairings.reduce((x, y) => getIntersectionOfArrays(x, y));
 
-    expect(repeatedDevPairsInEveryRotation).toHaveLength(0);
+  expect(repeatedDevPairsInEveryRotation).toHaveLength(0);
 
-    const allDevAndBoardCombos = allPairs.map(results => results.flatMap(pair => pair.devs.map(dev => [dev, pair.board])));
-    const repeatedDevAndBoardCombosInEveryRotation = allDevAndBoardCombos.reduce((x, y) => getIntersectionOfArrays(x, y));
+  const allDevAndBoardCombos = allPairs.map(results => results.flatMap(pair => pair.devs.map(dev => [dev, pair.board])));
+  const repeatedDevAndBoardCombosInEveryRotation = allDevAndBoardCombos.reduce((x, y) => getIntersectionOfArrays(x, y));
 
-    expect(repeatedDevAndBoardCombosInEveryRotation).toHaveLength(0);
+  expect(repeatedDevAndBoardCombosInEveryRotation).toHaveLength(0);
 }
 
 function getIntersectionOfArrays(firstArrays: any[][], secondArrays: any[][]): any[][] {
-    return firstArrays.filter(firstArray =>
-        secondArrays.find(secondArray =>
-            arraysAreEqual(firstArray, secondArray)
-        )
-    );
+  return firstArrays.filter(firstArray =>
+    secondArrays.find(secondArray =>
+      arraysAreEqual(firstArray, secondArray)
+    )
+  );
 }

--- a/src/app/services/rotation.service.ts
+++ b/src/app/services/rotation.service.ts
@@ -22,7 +22,7 @@ export class RotationService {
     const sticking = this.localStorageService.getSticking();
     const stickingBoards = sticking.map(pair => pair.board);
     const stickingDevs = sticking.flatMap(pair => pair.devs);
-    const pairs = sticking;
+    const pairs = [...sticking];
 
     devs = devs.filter(dev => !disabled.includes(dev));
     devs = devs.filter(dev => !stickingDevs.includes(dev));

--- a/src/app/services/rotation.service.ts
+++ b/src/app/services/rotation.service.ts
@@ -14,45 +14,53 @@ export class RotationService {
   }
 
   makeItRotato(): Pair[] {
-    let carriers = this.localStorageService.getCarriers();
     let devs = this.localStorageService.getDevs();
     let boards = this.localStorageService.getBoards();
     const disabled = this.localStorageService.getDisabled();
     const disabledBoards = this.localStorageService.getDisabledBoards();
     const sticking = this.localStorageService.getSticking();
+    let carryingPairs = this.getCarryingPairs();
+
     const stickingBoards = sticking.map(pair => pair.board);
     const stickingDevs = sticking.flatMap(pair => pair.devs);
+    const carriersInRotation = carryingPairs.flatMap(pair => pair.devs);
+    const carryingBoardsInRotation = carryingPairs.map(pair => pair.board);
+
     const pairs = [...sticking];
 
     devs = devs.filter(dev => !disabled.includes(dev));
     devs = devs.filter(dev => !stickingDevs.includes(dev));
-    devs = devs.filter(dev => !carriers.includes(dev));
+    devs = devs.filter(dev => !carriersInRotation.includes(dev));
     boards = boards.filter(board => !disabledBoards.includes(board));
     boards = boards.filter(board => !stickingBoards.includes(board));
-    carriers = carriers.filter(carrier => !stickingDevs.includes(carrier));
+    boards = boards.filter(board => !carryingBoardsInRotation.includes(board));
+    carryingPairs = carryingPairs.filter(carryingPair =>
+      stickingDevs.findIndex(dev => carryingPair.devs.includes(dev)) < 0
+    );
 
-    shuffle(carriers);
+    shuffle(carryingPairs);
     shuffle(boards);
     shuffle(devs);
 
-    for (const carrier of carriers) {
-      const partner = devs.splice(0, 1)[0];
-      if (partner) {
+    for (const pair of carryingPairs) {
+      if (pair.devs.length < 2) {
+        const dev = pair.devs[0];
+        const partner = devs.splice(0, 1)[0];
+
+        let board = pair.board;
+        if (!board || disabledBoards.includes(board)) {
+          board = boards.pop();
+        }
+
         pairs.push(
           {
-            board: boards.pop(),
+            board: board,
             devs:
-              [carrier, partner]
+              [dev, partner].filter(x => !!x)
           }
         );
       } else {
-        pairs.push(
-          {
-            board: boards.pop(),
-            devs:
-              [carrier]
-          }
-        );
+        pairs.push(pair);
       }
     }
 
@@ -86,5 +94,18 @@ export class RotationService {
     }
 
     return pairs;
+  }
+
+  private getCarryingPairs(): Pair[] {
+    const carriers = this.localStorageService.getCarriers();
+
+    const carryingPairsFromPreviousRotation = this.localStorageService.getPairs()
+      .filter(pair => carriers.findIndex(carrier => pair.devs.includes(carrier)) >= 0)
+      .map(pair => <Pair>{board: pair.board, devs: pair.devs.filter(dev => carriers.includes(dev))});
+
+    const remainingCarriers = carriers.filter(carrier => !carryingPairsFromPreviousRotation.flatMap(pair => pair.devs).includes(carrier))
+      .map(carrier => <Pair>{board: undefined, devs: [carrier]});
+
+    return carryingPairsFromPreviousRotation.concat(remainingCarriers);
   }
 }

--- a/src/app/utillity/helper-methods.ts
+++ b/src/app/utillity/helper-methods.ts
@@ -1,22 +1,22 @@
 export function replaceIfExists<T>(array: T[], oldValue: T, newValue: T): T[] {
-    const arrayIndex = array.indexOf(oldValue);
+  const arrayIndex = array.indexOf(oldValue);
 
-    if (arrayIndex < 0) {
-        return null;
-    }
+  if (arrayIndex < 0) {
+    return null;
+  }
 
-    array[array.indexOf(oldValue)] = newValue;
-    return array;
+  array[array.indexOf(oldValue)] = newValue;
+  return array;
 }
 
 export function removeIfExists<T>(array: T[], value: T): T[] {
-    const arrayIndex = array.indexOf(value);
+  const arrayIndex = array.indexOf(value);
 
-    if (arrayIndex < 0) {
-        return null;
-    }
+  if (arrayIndex < 0) {
+    return null;
+  }
 
-    const splicedArray = [...array];
-    splicedArray.splice(array.indexOf(value), 1);
-    return splicedArray;
+  const splicedArray = [...array];
+  splicedArray.splice(array.indexOf(value), 1);
+  return splicedArray;
 }

--- a/src/app/utillity/spuddy-data.ts
+++ b/src/app/utillity/spuddy-data.ts
@@ -1,36 +1,36 @@
 import { Pair } from './pair';
 
 export class SpuddyData {
-    pairs: Pair[];
-    sticking: Pair[];
-    carriers: string[];
-    boards: string[];
-    disabled: string[];
-    disabledBoards: string[];
-    availableDevs: string[];
+  pairs: Pair[];
+  sticking: Pair[];
+  carriers: string[];
+  boards: string[];
+  disabled: string[];
+  disabledBoards: string[];
+  availableDevs: string[];
 
-    constructor(
-        pairs: Pair[],
-        sticking: Pair[],
-        carriers: string[],
-        boards: string[],
-        disabled: string[],
-        disabledBoards: string[],
-        devs: string[]
-    ) {
-        this.pairs = pairs;
-        this.carriers = carriers;
-        this.disabled = disabled;
-        this.boards = boards;
-        this.disabledBoards = disabledBoards;
-        this.sticking = sticking;
+  constructor(
+    pairs: Pair[],
+    sticking: Pair[],
+    carriers: string[],
+    boards: string[],
+    disabled: string[],
+    disabledBoards: string[],
+    devs: string[]
+  ) {
+    this.pairs = pairs;
+    this.carriers = carriers;
+    this.disabled = disabled;
+    this.boards = boards;
+    this.disabledBoards = disabledBoards;
+    this.sticking = sticking;
 
-        const devsInRotation = pairs.flatMap(x => x.devs);
-        this.availableDevs = [];
-        for (const dev of devs) {
-            if (!devsInRotation.includes(dev) && !disabled.includes(dev)) {
-                this.availableDevs.push(dev);
-            }
-        }
+    const devsInRotation = pairs.flatMap(x => x.devs);
+    this.availableDevs = [];
+    for (const dev of devs) {
+      if (!devsInRotation.includes(dev) && !disabled.includes(dev)) {
+        this.availableDevs.push(dev);
+      }
     }
+  }
 }


### PR DESCRIPTION
This pull request includes the most of the updated carrying logic mentioned in #21, It does not include marking pairs as sticking when all devs in a pair are marked as carrying.

This pull request also backfills all of the tests for the rotation service. I tried to make the tests as agnostic as possible to the actual randomizing and pairing logic, which required a lot of weird helper methods for testing the edge cases in the rotation service. If there's anything that seems unnecessary or can be refactored let me know.

I also fixed the indentation in some of the other files I made so that everything is 2 spaces instead of 4.