### PR TITLE
Pin options menu to the bottom of the screen

### DIFF
--- a/src/app/footer/footer.component.scss
+++ b/src/app/footer/footer.component.scss
@@ -5,6 +5,11 @@
   justify-content: flex-end;
 }
 
+app-menu {
+  position: fixed;
+  bottom: 0;
+}
+
 a{
   color: black;
 }


### PR DESCRIPTION
This pull request fixes the issue mentioned in #26 

The only issue now is that the options menu is hard to see on certain themes when it is in front of the boards. Do you think the options menu should be styled in a way to make it more visible in this scenario?

![Screenshot 2021-06-27 at 12-19-24 🔄+🥔=🍐](https://user-images.githubusercontent.com/31396523/123553636-006eb200-d742-11eb-83e5-58f03e276af2.png)
