### PR TITLE
Update delete board logic to remove empty pairs with board

### DIFF
--- a/src/app/services/board.service.spec.ts
+++ b/src/app/services/board.service.spec.ts
@@ -301,5 +301,23 @@ describe('BoardService', () => {
 
       expect(localStorageService.setSticking).not.toHaveBeenCalled();
     });
+
+    it('should remove pair completely when board is removed from a pair with no devs', () => {
+      
+      localStorageService.getBoards.mockReturnValue([]);
+      localStorageService.getDisabledBoards.mockReturnValue([]);
+      localStorageService.getSticking.mockReturnValue([]);
+
+      localStorageService.getPairs.mockReturnValue(shuffle([
+        {board: boardToDelete, devs: []},
+        {board: firstOtherBoardName, devs: firstPairDevs}
+      ]));
+
+      boardService.delete(boardToDelete);
+
+      expect(localStorageService.setPairs).toHaveBeenCalledWith([
+        {board: firstOtherBoardName, devs: firstPairDevs}
+      ]);
+    });
   });
 });

--- a/src/app/services/board.service.ts
+++ b/src/app/services/board.service.ts
@@ -63,6 +63,18 @@ export class BoardService {
   }
 
   private removeBoardInPairIfExists(pairs: Pair[], value: string): Pair[] {
-    return this.replaceBoardInPairIfExists(pairs, value, undefined);
+    const pairIndex = pairs.findIndex(x => x.board === value);
+
+    if (pairIndex < 0) {
+      return null;
+    }
+
+    if (pairs[pairIndex].devs.length === 0) {
+      pairs.splice(pairIndex, 1);
+    } else {
+      pairs[pairIndex].board = undefined;
+    }
+
+    return pairs;  
   }
 }


### PR DESCRIPTION
I noticed that if there was a board in rotation without any devs, and the board was deleted, there would still be an empty pairing slot in rotation. This pull request updates the board deletion logic so that the pairing slot is completely removed if the board doesn't have any devs on it.