### PR TITLE
Add undefined check in sound service when playing sounds

### DIFF
--- a/src/app/services/sound.service.ts
+++ b/src/app/services/sound.service.ts
@@ -43,7 +43,7 @@ export class SoundService {
     if (this.soundEnabled) {
       sound.load();
       sound.volume = this.volume;
-      sound.play().then();
+      sound.play()?.then();
     }
   }
 }


### PR DESCRIPTION
Another team found a bug while using rotato with a plugin that prevents autoplaying audio. The page wasn't properly reloading on actions such as creating devs and boards because the sound service was throwing an undefined error. This should be enough to fix the issue.

Here's the plugin they were using:
https://chrome.google.com/webstore/detail/disable-html5-autoplay/efdhoaajjjgckpbkoglidkeendpkolai